### PR TITLE
Adding AccountId and AccountName parameters to ZoneFilter

### DIFF
--- a/CloudFlare.Client/Api/Parameters/Filtering.cs
+++ b/CloudFlare.Client/Api/Parameters/Filtering.cs
@@ -11,6 +11,11 @@
         public const string AccountName = "account.name";
 
         /// <summary>
+        /// Account identifier tag on CloudFlare
+        /// </summary>
+        public const string AccountId = "account.id";
+
+        /// <summary>
         /// Content representation on CloudFlare
         /// </summary>
         public const string Content = "content";

--- a/CloudFlare.Client/Api/Zones/ZoneFilter.cs
+++ b/CloudFlare.Client/Api/Zones/ZoneFilter.cs
@@ -8,13 +8,25 @@ namespace CloudFlare.Client.Api.Zones
         /// A domain name
         /// </summary>
         public string Name { get; set; }
+
         /// <summary>
         /// Status of the zone<
         /// </summary>
         public ZoneStatus? Status { get; set; }
+
         /// <summary>
         /// Whether to match all search requirements or at least one
         /// </summary>
         public bool? Match { get; set; }
+
+        /// <summary>
+        /// Account name
+        /// </summary>
+        public string AccountName { get; set; }
+
+        /// <summary>
+        /// Account identifier tag
+        /// </summary>
+        public string AccountId { get; set; }
     }
 }

--- a/CloudFlare.Client/Client/Zones/Zones.cs
+++ b/CloudFlare.Client/Client/Zones/Zones.cs
@@ -47,6 +47,8 @@ namespace CloudFlare.Client.Client.Zones
         public async Task<CloudFlareResult<IReadOnlyList<Zone>>> GetAsync(ZoneFilter filter = null, DisplayOptions displayOptions = null, CancellationToken cancellationToken = default)
         {
             var builder = new ParameterBuilderHelper()
+                .InsertValue(Filtering.AccountId, filter?.AccountId)
+                .InsertValue(Filtering.AccountName, filter?.AccountName)
                 .InsertValue(Filtering.Name, filter?.Name)
                 .InsertValue(Filtering.Status, filter?.Status)
                 .InsertValue(Filtering.Match, filter?.Match)


### PR DESCRIPTION
Zone filter did not have the ability to provide AccountName (account.name) or AccountId (account.id) - Added these into the model and parameter creation.