### PR TITLE
Fix SRV record creation

### DIFF
--- a/CloudFlare.Client.Test/Accounts/AccountsUnitTests.cs
+++ b/CloudFlare.Client.Test/Accounts/AccountsUnitTests.cs
@@ -70,32 +70,32 @@ namespace CloudFlare.Client.Test.Accounts
         [Fact]
         public async Task UpdateAccountAsync()
         {
-            var account = AccountTestData.Accounts.First();
+            var expectedAccount = AccountTestData.Accounts.First();
 
             _wireMockServer
-                .Given(Request.Create().WithPath($"/{AccountEndpoints.Base}/{account.Id}").UsingPut())
+                .Given(Request.Create().WithPath($"/{AccountEndpoints.Base}/{expectedAccount.Id}").UsingPut())
                 .RespondWith(Response.Create().WithStatusCode(200).WithBody(x =>
                 {
                     var body = JsonConvert.DeserializeObject<Account>(x.Body);
-                    var acc = AccountTestData.Accounts.First(y => y.Id == body.Id).DeepClone();
+                    var account = AccountTestData.Accounts.First(y => y.Id == body.Id).DeepClone();
 
-                    acc.Id = body.Id;
-                    acc.Name = body.Name;
-                    acc.Settings = body.Settings;
+                    account.Id = body.Id;
+                    account.Name = body.Name;
+                    account.Settings = body.Settings;
 
-                    return WireMockResponseHelper.CreateTestResponse(acc);
+                    return WireMockResponseHelper.CreateTestResponse(account);
                 }));
 
             using var client = new CloudFlareClient(WireMockConnection.ApiKeyAuthentication, _connectionInfo);
 
-            var updatedAccount = await client.Accounts.UpdateAsync(account.Id, "New Name", new AdditionalAccountSettings
+            var updatedAccount = await client.Accounts.UpdateAsync(expectedAccount.Id, "New Name", new AdditionalAccountSettings
             {
                 EnforceTwoFactorAuthentication = true
             });
 
             updatedAccount.Result.Name.Should().Be("New Name");
             updatedAccount.Result.Settings.EnforceTwoFactorAuthentication.Should().BeTrue();
-            updatedAccount.Result.Should().BeEquivalentTo(account, opt => opt.Excluding(x => x.Name).Excluding(x => x.Settings.EnforceTwoFactorAuthentication));
+            updatedAccount.Result.Should().BeEquivalentTo(expectedAccount, opt => opt.Excluding(x => x.Name).Excluding(x => x.Settings.EnforceTwoFactorAuthentication));
         }
     }
 }

--- a/CloudFlare.Client.Test/Attribute/DnsRecordDataTypeTests.cs
+++ b/CloudFlare.Client.Test/Attribute/DnsRecordDataTypeTests.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using CloudFlare.Client.Attributes;
+using CloudFlare.Client.Enumerators;
+using CloudFlare.Client.Extensions;
+using CloudFlare.Client.Test.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace CloudFlare.Client.Test.Attribute
+{
+    public class DnsRecordDataTypeTests
+    {
+        [Theory]
+        [MemberData(nameof(EnumHelper<DnsRecordType>.GetValuesOfWithoutAttribute), typeof(DataTypeDnsRecordAttribute), MemberType = typeof(EnumHelper<DnsRecordType>))]
+        public void NotDataTypedDnsRecord_EnsureIsNotDataType_NoException(DnsRecordType dnsRecordType)
+        {
+            Action act = () => dnsRecordType.EnsureIsNotDataType();
+
+            act.Should().NotThrow();
+        }
+
+        [Theory]
+        [MemberData(nameof(EnumHelper<DnsRecordType>.GetValuesOfWithoutAttribute), typeof(DataTypeDnsRecordAttribute), MemberType = typeof(EnumHelper<DnsRecordType>))]
+        public void NotDataTypedDnsRecord_EnsureIsDataType_NotSupportedException(DnsRecordType dnsRecordType)
+        {
+            Action act = () => dnsRecordType.EnsureIsDataType();
+
+            act.Should().Throw<NotSupportedException>();
+        }
+
+        [Theory]
+        [MemberData(nameof(EnumHelper<DnsRecordType>.GetValuesOfWithAttribute), typeof(DataTypeDnsRecordAttribute), MemberType = typeof(EnumHelper<DnsRecordType>))]
+        public void DataTypedDnsRecord_EnsureIsDataType_NoException(DnsRecordType dnsRecordType)
+        {
+            Action act = () => dnsRecordType.EnsureIsDataType();
+
+            act.Should().NotThrow();
+        }
+
+        [Theory]
+        [MemberData(nameof(EnumHelper<DnsRecordType>.GetValuesOfWithAttribute), typeof(DataTypeDnsRecordAttribute), MemberType = typeof(EnumHelper<DnsRecordType>))]
+        public void DataTypedDnsRecord_EnsureIsNotDataType_NotSupportedException(DnsRecordType dnsRecordType)
+        {
+            Action act = () => dnsRecordType.EnsureIsNotDataType();
+
+            act.Should().Throw<NotSupportedException>();
+        }
+    }
+}

--- a/CloudFlare.Client.Test/CloudFlare.Client.Test.csproj
+++ b/CloudFlare.Client.Test/CloudFlare.Client.Test.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.0.1">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.0.1">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="DeepCloner" Version="0.10.2" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="WireMock.Net" Version="1.4.0" />
+    <PackageReference Include="DeepCloner" Version="0.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="WireMock.Net" Version="1.4.29" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/CloudFlare.Client.Test/Helpers/EnumHelper.cs
+++ b/CloudFlare.Client.Test/Helpers/EnumHelper.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CloudFlare.Client.Test.Helpers
+{
+    public static class EnumHelper<T>
+         where T : Enum
+    {
+        public static IEnumerable<object[]> GetValuesOf(IEnumerable<T> excepts)
+        {
+            foreach (var item in Enum.GetValues(typeof(T)).Cast<T>().Where(x => !excepts.Contains(x)))
+            {
+                yield return new object[] { item };
+            }
+        }
+
+        public static IEnumerable<object[]> GetValuesOfWithAttribute(Type attributeType)
+        {
+            foreach (var item in Enum.GetValues(typeof(T)).Cast<T>().Where(x => typeof(T).GetField(x.ToString()).IsDefined(attributeType, false)))
+            {
+                yield return new object[] { item };
+            }
+        }
+
+        public static IEnumerable<object[]> GetValuesOfWithoutAttribute(Type attributeType)
+        {
+            foreach (var item in Enum.GetValues(typeof(T)).Cast<T>().Where(x => !typeof(T).GetField(x.ToString()).IsDefined(attributeType, false)))
+            {
+                yield return new object[] { item };
+            }
+        }
+    }
+}

--- a/CloudFlare.Client.Test/TestData/AccountMembershipTestData.cs
+++ b/CloudFlare.Client.Test/TestData/AccountMembershipTestData.cs
@@ -5,7 +5,7 @@ using CloudFlare.Client.Enumerators;
 
 namespace CloudFlare.Client.Test.TestData
 {
-    public class AccountMembershipTestData
+    public static class AccountMembershipTestData
     {
         public static List<Member> Members { get; set; } = new()
         {

--- a/CloudFlare.Client.Test/TestData/AccountTestData.cs
+++ b/CloudFlare.Client.Test/TestData/AccountTestData.cs
@@ -5,7 +5,7 @@ using CloudFlare.Client.Enumerators;
 
 namespace CloudFlare.Client.Test.TestData
 {
-    public class AccountTestData
+    public static class AccountTestData
     {
         public static List<Account> Accounts { get; set; } = new()
         {

--- a/CloudFlare.Client.Test/TestData/DnsRecordTestData.cs
+++ b/CloudFlare.Client.Test/TestData/DnsRecordTestData.cs
@@ -19,6 +19,7 @@ namespace CloudFlare.Client.Test.TestData
                 Name = "tothnet.hu",
                 Proxiable = true,
                 Proxied = false,
+                Priority = 10,
                 Ttl = 120,
                 Type = DnsRecordType.A,
                 ZoneId = "023e105f4ecef8ad9ca31a8372d0c353",

--- a/CloudFlare.Client.Test/TestData/RoleTestData.cs
+++ b/CloudFlare.Client.Test/TestData/RoleTestData.cs
@@ -3,7 +3,7 @@ using CloudFlare.Client.Api.Accounts.Roles;
 
 namespace CloudFlare.Client.Test.TestData
 {
-    public class RoleTestData
+    public static class RoleTestData
     {
         public static List<Role> Roles { get; set; } = new()
         {

--- a/CloudFlare.Client.Test/TestData/UserTestData.cs
+++ b/CloudFlare.Client.Test/TestData/UserTestData.cs
@@ -4,7 +4,7 @@ using CloudFlare.Client.Api.Users;
 
 namespace CloudFlare.Client.Test.TestData
 {
-    public class UserTestData
+    public static class UserTestData
     {
         public static List<User> Users { get; set; } = new()
         {

--- a/CloudFlare.Client.Test/TestData/ZoneTestData.cs
+++ b/CloudFlare.Client.Test/TestData/ZoneTestData.cs
@@ -6,7 +6,7 @@ using CloudFlare.Client.Enumerators;
 
 namespace CloudFlare.Client.Test.TestData
 {
-    public class ZoneTestData
+    public static class ZoneTestData
     {
         public static List<Zone> Zones { get; set; } = new()
         {

--- a/CloudFlare.Client.Test/WireMockConnection.cs
+++ b/CloudFlare.Client.Test/WireMockConnection.cs
@@ -7,9 +7,13 @@ namespace CloudFlare.Client.Test
     public class WireMockConnection
     {
         public static string EmailAddress { get; } = "test@tothnet.hu";
+
         public static string Key { get; } = "p@ssw0rd";
+
         public static string Token { get; } = "8M7wS6hCpXVc-DoRnPPY_UCWPgy8aea4Wy6kCe5T";
+
         public static ApiKeyAuthentication ApiKeyAuthentication { get; } = new(EmailAddress, Key);
+
         public static ApiTokenAuthentication ApiTokenAuthentication { get; } = new(Token);
 
         public ConnectionInfo ConnectionInfo { get; }

--- a/CloudFlare.Client.Test/Zones/CustomHostnamesUnitTests.cs
+++ b/CloudFlare.Client.Test/Zones/CustomHostnamesUnitTests.cs
@@ -120,7 +120,7 @@ namespace CloudFlare.Client.Test.Zones
             var editCustomHostname = await client.Zones.CustomHostnames.UpdateAsync(zone.Id, customHostname.Id, modified);
 
             editCustomHostname.Result.Should().BeEquivalentTo(customHostname, opt => opt.Excluding(y => y.Ssl.Settings.Tls13));
-            editCustomHostname.Result.Ssl.Settings.Tls13.Should().BeEquivalentTo(FeatureStatus.Off);
+            editCustomHostname.Result.Ssl.Settings.Tls13.Should().Be(FeatureStatus.Off);
         }
 
         [Fact]

--- a/CloudFlare.Client.Test/Zones/DnsRecordUnitTests.cs
+++ b/CloudFlare.Client.Test/Zones/DnsRecordUnitTests.cs
@@ -1,7 +1,9 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
+using CloudFlare.Client.Api.Authentication;
 using CloudFlare.Client.Api.Display;
 using CloudFlare.Client.Api.Parameters;
+using CloudFlare.Client.Api.Parameters.Data;
 using CloudFlare.Client.Api.Parameters.Endpoints;
 using CloudFlare.Client.Api.Zones.DnsRecord;
 using CloudFlare.Client.Contexts;
@@ -34,7 +36,7 @@ namespace CloudFlare.Client.Test.Zones
         {
             var zone = ZoneTestData.Zones.First();
             var dnsRecord = DnsRecordTestData.DnsRecords.First();
-            var newZone = new NewDnsRecord
+            var newRecord = new NewDnsRecord
             {
                 Name = dnsRecord.Name,
                 Content = dnsRecord.Content,
@@ -51,7 +53,7 @@ namespace CloudFlare.Client.Test.Zones
 
             using var client = new CloudFlareClient(WireMockConnection.ApiKeyAuthentication, _connectionInfo);
 
-            var created = await client.Zones.DnsRecords.AddAsync(zone.Id, newZone);
+            var created = await client.Zones.DnsRecords.AddAsync(zone.Id, newRecord);
 
             created.Result.Should().BeEquivalentTo(dnsRecord);
         }

--- a/CloudFlare.Client.Test/Zones/DnsRecordUnitTests.cs
+++ b/CloudFlare.Client.Test/Zones/DnsRecordUnitTests.cs
@@ -62,7 +62,6 @@ namespace CloudFlare.Client.Test.Zones
         public async Task TestCreateDataDnsRecordAsync()
         {
             var zone = ZoneTestData.Zones.First();
-            var dnsRecord = DnsRecordTestData.DnsRecords.First();
             var newRecord = new NewDnsRecord<Srv>
             {
                 Type = DnsRecordType.Srv,
@@ -79,6 +78,10 @@ namespace CloudFlare.Client.Test.Zones
                 Proxied = true,
                 Ttl = 12,
             };
+            var dnsRecord = DnsRecordTestData.DnsRecords.First();
+            dnsRecord.Type = newRecord.Type;
+            dnsRecord.Priority = newRecord.Data.Priority;
+            dnsRecord.Data = newRecord.Data as object;
 
             _wireMockServer
                 .Given(Request.Create().WithPath($"/{ZoneEndpoints.Base}/{zone.Id}/{DnsRecordEndpoints.Base}").UsingPost())
@@ -89,7 +92,8 @@ namespace CloudFlare.Client.Test.Zones
 
             var created = await client.Zones.DnsRecords.AddAsync(zone.Id, newRecord);
 
-            created.Result.Should().BeEquivalentTo(dnsRecord);
+            created.Result.Should().BeEquivalentTo(dnsRecord, c => c.Excluding(p => p.Data));
+            JsonConvert.DeserializeObject<Srv>(created.Result.Data.ToString()).Should().BeEquivalentTo(dnsRecord.Data);
         }
 
         

--- a/CloudFlare.Client/Api/Parameters/Data/IData.cs
+++ b/CloudFlare.Client/Api/Parameters/Data/IData.cs
@@ -1,0 +1,6 @@
+﻿namespace CloudFlare.Client.Api.Parameters.Data
+{
+    public interface IData
+    {
+    }
+}

--- a/CloudFlare.Client/Api/Parameters/Data/Srv.cs
+++ b/CloudFlare.Client/Api/Parameters/Data/Srv.cs
@@ -5,11 +5,6 @@ namespace CloudFlare.Client.Api.Parameters.Data
 {
     public class Srv : IData
     {
-        public Srv()
-        {
-
-        }
-
         /// <summary>
         /// Service name of the SRV record
         /// </summary>

--- a/CloudFlare.Client/Api/Parameters/Data/Srv.cs
+++ b/CloudFlare.Client/Api/Parameters/Data/Srv.cs
@@ -5,6 +5,11 @@ namespace CloudFlare.Client.Api.Parameters.Data
 {
     public class Srv : IData
     {
+        public Srv()
+        {
+
+        }
+
         /// <summary>
         /// Service name of the SRV record
         /// </summary>
@@ -18,17 +23,18 @@ namespace CloudFlare.Client.Api.Parameters.Data
         public Protocol Protocol { get; set; }
 
         /// <summary>
-        /// Name of the SRV record
-        /// Use @ for root
+        /// <para>Name of the SRV record</para>
+        /// <para>Use @ for root</para>
         /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }
 
         /// <summary>
-        /// Priority of the SRV record
+        /// Used with some records like MX and SRV to determine priority.
+        /// If you do not supply a priority for an MX record, a default value of 0 will be set
         /// </summary>
         [JsonProperty("priority")]
-        public long Priority { get; set; }
+        public int Priority { get; set; }
 
         /// <summary>
         /// Weight of the SRV record

--- a/CloudFlare.Client/Api/Parameters/Data/Srv.cs
+++ b/CloudFlare.Client/Api/Parameters/Data/Srv.cs
@@ -1,0 +1,51 @@
+﻿using CloudFlare.Client.Enumerators;
+using Newtonsoft.Json;
+
+namespace CloudFlare.Client.Api.Parameters.Data
+{
+    public class Srv : IData
+    {
+        /// <summary>
+        /// Service name of the SRV record
+        /// </summary>
+        [JsonProperty("service")]
+        public string Service { get; set; }
+
+        /// <summary>
+        /// Protocol of the SRV record
+        /// </summary>
+        [JsonProperty("proto")]
+        public Protocol Protocol { get; set; }
+
+        /// <summary>
+        /// Name of the SRV record
+        /// Use @ for root
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Priority of the SRV record
+        /// </summary>
+        [JsonProperty("priority")]
+        public long Priority { get; set; }
+
+        /// <summary>
+        /// Weight of the SRV record
+        /// </summary>
+        [JsonProperty("weight")]
+        public int Weight { get; set; }
+
+        /// <summary>
+        /// Port of the SRV record
+        /// </summary>
+        [JsonProperty("port")]
+        public int Port { get; set; }
+
+        /// <summary>
+        /// Target of the SRV record
+        /// </summary>
+        [JsonProperty("target")]
+        public string Target { get; set; }
+    }
+}

--- a/CloudFlare.Client/Api/Zones/DnsRecord/NewDnsRecord.cs
+++ b/CloudFlare.Client/Api/Zones/DnsRecord/NewDnsRecord.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using CloudFlare.Client.Api.Parameters.Data;
+using CloudFlare.Client.Attributes;
 using CloudFlare.Client.Enumerators;
+using CloudFlare.Client.Extensions;
 using Newtonsoft.Json;
 
 namespace CloudFlare.Client.Api.Zones.DnsRecord
@@ -18,32 +20,56 @@ namespace CloudFlare.Client.Api.Zones.DnsRecord
         /// </summary>
         [JsonProperty("content")]
         public string Content { get; set; }
+
+        /// <summary>
+        /// Used with some records like MX and SRV to determine priority.
+        /// If you do not supply a priority for an MX record, a default value of 0 will be set
+        /// </summary>
+        [JsonProperty("priority")]
+        public int? Priority { get; set; }
         
         /// <summary>
         /// DNS record type
         /// </summary>
         [JsonProperty("type")]
-        public DnsRecordType Type { get; set; }
+        public new DnsRecordType Type
+        {
+            get
+            {
+                return base.Type;
+            }
+            set
+            {
+                value.EnsureIsNotDataType();
+                base.Type = value;
+            }
+        }
     }
 
     public class NewDnsRecord<T> : NewDnsRecordBase
         where T : class, IData
     {
-        public NewDnsRecord()
-        {
-            Type = typeof(T) == typeof(Srv) ? DnsRecordType.Srv : throw new NotSupportedException($"{typeof(T)} is not supported Data type");
-        }
-        
-        /// <summary>
-        /// DNS record type
-        /// </summary>
-        [JsonProperty("type")]
-        public DnsRecordType Type { get; }
-        
         /// <summary>
         /// Data of the record
         /// </summary>
         [JsonProperty("data")]
         public T Data { get; set; }
+
+        /// <summary>
+        /// DNS record type
+        /// </summary>
+        [JsonProperty("type")]
+        public new DnsRecordType Type
+        {
+            get
+            {
+                return base.Type;
+            }
+            set
+            {
+                value.EnsureIsDataType();
+                base.Type = value;
+            }
+        }
     }
 }

--- a/CloudFlare.Client/Api/Zones/DnsRecord/NewDnsRecord.cs
+++ b/CloudFlare.Client/Api/Zones/DnsRecord/NewDnsRecord.cs
@@ -1,16 +1,12 @@
-﻿using CloudFlare.Client.Enumerators;
+﻿using System;
+using CloudFlare.Client.Api.Parameters.Data;
+using CloudFlare.Client.Enumerators;
 using Newtonsoft.Json;
 
 namespace CloudFlare.Client.Api.Zones.DnsRecord
 {
-    public class NewDnsRecord
+    public class NewDnsRecord : NewDnsRecordBase
     {
-        /// <summary>
-        /// DNS record type
-        /// </summary>
-        [JsonProperty("type")]
-        public DnsRecordType Type { get; set; }
-
         /// <summary>
         /// Name of the record
         /// </summary>
@@ -22,25 +18,32 @@ namespace CloudFlare.Client.Api.Zones.DnsRecord
         /// </summary>
         [JsonProperty("content")]
         public string Content { get; set; }
-
+        
         /// <summary>
-        /// Whether the record is receiving the performance and security benefits of CloudFlare
+        /// DNS record type
         /// </summary>
-        [JsonProperty("proxied")]
-        public bool? Proxied { get; set; }
+        [JsonProperty("type")]
+        public DnsRecordType Type { get; set; }
+    }
 
+    public class NewDnsRecord<T> : NewDnsRecordBase
+        where T : class, IData
+    {
+        public NewDnsRecord()
+        {
+            Type = typeof(T) == typeof(Srv) ? DnsRecordType.Srv : throw new NotSupportedException($"{typeof(T)} is not supported Data type");
+        }
+        
         /// <summary>
-        /// Used with some records like MX and SRV to determine priority.
-        /// If you do not supply a priority for an MX record, a default value of 0 will be set
+        /// DNS record type
         /// </summary>
-        [JsonProperty("priority")]
-        public int? Priority { get; set; }
-
+        [JsonProperty("type")]
+        public DnsRecordType Type { get; }
+        
         /// <summary>
-        /// Time to live (TTL) of the DNS entry for the IP address returned by this load balancer.
-        /// This only applies to gray-clouded (unproxied) load balancers.
+        /// Data of the record
         /// </summary>
-        [JsonProperty("ttl")]
-        public int? Ttl { get; set; }
+        [JsonProperty("data")]
+        public T Data { get; set; }
     }
 }

--- a/CloudFlare.Client/Api/Zones/DnsRecord/NewDnsRecordBase.cs
+++ b/CloudFlare.Client/Api/Zones/DnsRecord/NewDnsRecordBase.cs
@@ -1,0 +1,28 @@
+﻿using CloudFlare.Client.Enumerators;
+using Newtonsoft.Json;
+
+namespace CloudFlare.Client.Api.Zones.DnsRecord
+{
+    public abstract class NewDnsRecordBase
+    {
+        /// <summary>
+        /// Whether the record is receiving the performance and security benefits of CloudFlare
+        /// </summary>
+        [JsonProperty("proxied")]
+        public bool? Proxied { get; set; }
+
+        /// <summary>
+        /// Used with some records like MX and SRV to determine priority.
+        /// If you do not supply a priority for an MX record, a default value of 0 will be set
+        /// </summary>
+        [JsonProperty("priority")]
+        public int? Priority { get; set; }
+
+        /// <summary>
+        /// Time to live (TTL) of the DNS entry for the IP address returned by this load balancer.
+        /// This only applies to gray-clouded (unproxied) load balancers.
+        /// </summary>
+        [JsonProperty("ttl")]
+        public int? Ttl { get; set; }
+    }
+}

--- a/CloudFlare.Client/Api/Zones/DnsRecord/NewDnsRecordBase.cs
+++ b/CloudFlare.Client/Api/Zones/DnsRecord/NewDnsRecordBase.cs
@@ -6,17 +6,16 @@ namespace CloudFlare.Client.Api.Zones.DnsRecord
     public abstract class NewDnsRecordBase
     {
         /// <summary>
+        /// DNS record type
+        /// </summary>
+        [JsonProperty("type")]
+        public DnsRecordType Type { get; set; }
+        
+        /// <summary>
         /// Whether the record is receiving the performance and security benefits of CloudFlare
         /// </summary>
         [JsonProperty("proxied")]
         public bool? Proxied { get; set; }
-
-        /// <summary>
-        /// Used with some records like MX and SRV to determine priority.
-        /// If you do not supply a priority for an MX record, a default value of 0 will be set
-        /// </summary>
-        [JsonProperty("priority")]
-        public int? Priority { get; set; }
 
         /// <summary>
         /// Time to live (TTL) of the DNS entry for the IP address returned by this load balancer.

--- a/CloudFlare.Client/Attributes/DataTypeDnsRecordAttribute.cs
+++ b/CloudFlare.Client/Attributes/DataTypeDnsRecordAttribute.cs
@@ -1,0 +1,8 @@
+﻿namespace CloudFlare.Client.Attributes;
+
+public class DataTypeDnsRecordAttribute : System.Attribute
+{
+    public DataTypeDnsRecordAttribute()
+    {
+    }   
+}

--- a/CloudFlare.Client/Attributes/DataTypeDnsRecordAttribute.cs
+++ b/CloudFlare.Client/Attributes/DataTypeDnsRecordAttribute.cs
@@ -1,8 +1,12 @@
-﻿namespace CloudFlare.Client.Attributes;
+using System;
 
-public class DataTypeDnsRecordAttribute : System.Attribute
+namespace CloudFlare.Client.Attributes
 {
-    public DataTypeDnsRecordAttribute()
+    [AttributeUsage(AttributeTargets.Enum)]
+    public class DataTypeDnsRecordAttribute : Attribute
     {
-    }   
+        public DataTypeDnsRecordAttribute()
+        {
+        }   
+    }
 }

--- a/CloudFlare.Client/Attributes/DataTypeDnsRecordAttribute.cs
+++ b/CloudFlare.Client/Attributes/DataTypeDnsRecordAttribute.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace CloudFlare.Client.Attributes
 {
-    [AttributeUsage(AttributeTargets.Enum)]
+    [AttributeUsage(AttributeTargets.Field)]
     public class DataTypeDnsRecordAttribute : Attribute
     {
         public DataTypeDnsRecordAttribute()

--- a/CloudFlare.Client/Client/Zones/DnsRecords.cs
+++ b/CloudFlare.Client/Client/Zones/DnsRecords.cs
@@ -21,10 +21,10 @@ namespace CloudFlare.Client.Client.Zones
         }
 
         /// <inheritdoc />
-        public async Task<CloudFlareResult<DnsRecord>> AddAsync(string zoneId, NewDnsRecord newDnsRecord, CancellationToken cancellationToken = default)
+        public async Task<CloudFlareResult<DnsRecord>> AddAsync(string zoneId, NewDnsRecordBase newDnsRecord, CancellationToken cancellationToken = default)
         {
             var requestUri = $"{ZoneEndpoints.Base}/{zoneId}/{DnsRecordEndpoints.Base}";
-            return await Connection.PostAsync<DnsRecord, NewDnsRecord>(requestUri, newDnsRecord, cancellationToken).ConfigureAwait(false);
+            return await Connection.PostAsync<DnsRecord, NewDnsRecordBase>(requestUri, newDnsRecord, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />

--- a/CloudFlare.Client/Client/Zones/IDnsRecords.cs
+++ b/CloudFlare.Client/Client/Zones/IDnsRecords.cs
@@ -17,7 +17,7 @@ namespace CloudFlare.Client.Client.Zones
         /// <param name="newDnsRecord">New DNS record to add</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
-        Task<CloudFlareResult<DnsRecord>> AddAsync(string zoneId, NewDnsRecord newDnsRecord, CancellationToken cancellationToken = default);
+        Task<CloudFlareResult<DnsRecord>> AddAsync(string zoneId, NewDnsRecordBase newDnsRecord, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Delete DNS record

--- a/CloudFlare.Client/CloudFlare.Client.csproj
+++ b/CloudFlare.Client/CloudFlare.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Authors>Tamás Tóth</Authors>
     <Company>TothNET</Company>
     <Description>.NET library for communication with the Cloudflare service API.</Description>
@@ -21,15 +21,21 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>nuget_logo.png</PackageIcon>
     <PackageIconUrl>https://raw.githubusercontent.com/zingz0r/CloudFlare.Client/master/CloudFlare.Client/Resources/nuget_logo.png</PackageIconUrl>
-    <LangVersion>9</LangVersion>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>CloudFlare.Client.Test</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+    
   <ItemGroup>
     <None Include="..\LICENSE">
       <Pack>True</Pack>

--- a/CloudFlare.Client/Enumerators/DnsRecordType.cs
+++ b/CloudFlare.Client/Enumerators/DnsRecordType.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.Serialization;
+using CloudFlare.Client.Attributes;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
@@ -25,6 +26,7 @@ namespace CloudFlare.Client.Enumerators
         [EnumMember(Value = "LOC")]
         Loc,
 
+        [DataTypeDnsRecord]
         [EnumMember(Value = "SRV")]
         Srv,
 

--- a/CloudFlare.Client/Enumerators/Protocol.cs
+++ b/CloudFlare.Client/Enumerators/Protocol.cs
@@ -1,0 +1,20 @@
+﻿using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace CloudFlare.Client.Enumerators
+{
+    /// <summary>
+    /// Protocol
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum Protocol
+    {
+        [EnumMember(Value = "_tcp")]
+        Tcp,
+        [EnumMember(Value = "_udp")]
+        Udp,
+        [EnumMember(Value = "_tls")]
+        Tls
+    }
+}

--- a/CloudFlare.Client/Extensions/DnsRecordTypeExtensions.cs
+++ b/CloudFlare.Client/Extensions/DnsRecordTypeExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using CloudFlare.Client.Attributes;
+using CloudFlare.Client.Enumerators;
+
+namespace CloudFlare.Client.Extensions;
+
+internal static class DnsRecordTypeExtensions
+{
+    internal static void EnsureIsDataType(this DnsRecordType dnsRecordType)
+    {
+        var fieldInfo = typeof(DnsRecordType).GetField(dnsRecordType.ToString());
+        if (!fieldInfo.IsDefined(typeof(DataTypeDnsRecordAttribute), false))
+        {
+            throw new NotSupportedException($"{dnsRecordType} is not data type");
+        }
+    }
+    
+    internal static void EnsureIsNotDataType(this DnsRecordType dnsRecordType)
+    {
+        var fieldInfo = typeof(DnsRecordType).GetField(dnsRecordType.ToString());
+        if (fieldInfo.IsDefined(typeof(DataTypeDnsRecordAttribute), false))
+        {
+            throw new NotSupportedException($"{dnsRecordType} is data type");
+        }
+    }
+}

--- a/CloudFlare.Client/Extensions/DnsRecordTypeExtensions.cs
+++ b/CloudFlare.Client/Extensions/DnsRecordTypeExtensions.cs
@@ -8,19 +8,22 @@ internal static class DnsRecordTypeExtensions
 {
     internal static void EnsureIsDataType(this DnsRecordType dnsRecordType)
     {
-        var fieldInfo = typeof(DnsRecordType).GetField(dnsRecordType.ToString());
-        if (!fieldInfo.IsDefined(typeof(DataTypeDnsRecordAttribute), false))
-        {
+        if(!dnsRecordType.IsDataType())
+        { 
             throw new NotSupportedException($"{dnsRecordType} is not data type");
         }
     }
     
     internal static void EnsureIsNotDataType(this DnsRecordType dnsRecordType)
     {
-        var fieldInfo = typeof(DnsRecordType).GetField(dnsRecordType.ToString());
-        if (fieldInfo.IsDefined(typeof(DataTypeDnsRecordAttribute), false))
+        if (dnsRecordType.IsDataType())
         {
             throw new NotSupportedException($"{dnsRecordType} is data type");
         }
+    }
+
+    internal static bool IsDataType(this DnsRecordType dnsRecordType)
+    {
+        return typeof(DnsRecordType).GetField(dnsRecordType.ToString()).IsDefined(typeof(DataTypeDnsRecordAttribute), false);
     }
 }

--- a/CloudFlare.Client/Extensions/HttpResponseMessageExtensions.cs
+++ b/CloudFlare.Client/Extensions/HttpResponseMessageExtensions.cs
@@ -12,9 +12,9 @@ using Newtonsoft.Json.Linq;
 
 namespace CloudFlare.Client.Extensions
 {
-    public static class HttpResponseMessageExtensions
+    internal static class HttpResponseMessageExtensions
     {
-        public static async Task<CloudFlareResult<T>> GetCloudFlareResultAsync<T>(this HttpResponseMessage response)
+        internal static async Task<CloudFlareResult<T>> GetCloudFlareResultAsync<T>(this HttpResponseMessage response)
         {
             try
             {

--- a/CloudFlare.Client/Helpers/FileHelper.cs
+++ b/CloudFlare.Client/Helpers/FileHelper.cs
@@ -4,9 +4,9 @@ using System.Threading.Tasks;
 
 namespace CloudFlare.Client.Helpers
 {
-    public static class FileHelper
+    internal static class FileHelper
     {
-        public static async Task<byte[]> ReadAsync(string path, CancellationToken cancellationToken)
+        internal static async Task<byte[]> ReadAsync(string path, CancellationToken cancellationToken)
         {
             using var sourceStream = File.Open(path, FileMode.Open);
             var result = new byte[sourceStream.Length];

--- a/CloudFlare.Client/Helpers/HttpContentTypesHelper.cs
+++ b/CloudFlare.Client/Helpers/HttpContentTypesHelper.cs
@@ -1,6 +1,6 @@
 ﻿namespace CloudFlare.Client.Helpers
 {
-    static class HttpContentTypesHelper
+    internal static class HttpContentTypesHelper
     {
         public const string Text = "text/plain";
         public const string Xml = "application/xml";

--- a/CloudFlare.Client/Helpers/ParameterBuilderHelper.cs
+++ b/CloudFlare.Client/Helpers/ParameterBuilderHelper.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json;
 
 namespace CloudFlare.Client.Helpers
 {
-    public class ParameterBuilderHelper
+    internal class ParameterBuilderHelper
     {
         /// <summary>
         /// Property that holds the parameters

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,13 @@ stages:
             sonar.cs.opencover.reportsPaths=$(Build.SourcesDirectory)/**/coverage.**.opencover.xml
             sonar.cs.vstest.reportsPaths=$(Agent.TempDirectory)/*.trx
       
+      - task: UseDotNet@2
+        displayName: 'Install .NET 6 SDK'
+        inputs:
+          packageType: 'sdk'
+          version: '6.0.x'
+          performMultiLevelLookup: true
+
       - task: DotNetCoreCLI@2
         displayName: Restore
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,6 +40,7 @@ stages:
         displayName: Restore
         inputs:
           command: 'restore'
+          arguments: '--verbosity normal'
           projects: '**/*.csproj'
           feedsToUse: 'select'
           vstsFeed: 'd5f72524-9a3d-4cca-ac65-8688b67830d4/f7ea4fd7-43dc-4f24-a491-8f013b20ab55'


### PR DESCRIPTION
fix for #44 

To Create Srv Record:
```  csharp
    using var client = new CloudFlareClient("apiToken");
    var zone = (await client.Zones.GetAsync()).Result.First();
    var newRecord = new NewDnsRecord<Srv>
    {
        Type = DnsRecordType.Srv,
        Data = new Srv
        {
            Name = "@",
            Port = 1234,
            Priority = 5,
            Protocol = Protocol.Tcp,
            Service = "_servicename",
            Target = "servicename.tothnet.hu",
            Weight = 5
        },
        Proxied = true,
        Ttl = 12,
    };
    
    var created = await client.Zones.DnsRecords.AddAsync(zone.Id, newRecord);