### PR TITLE
Number of custom hostname fixes

### DIFF
--- a/CloudFlare.Client.Test/Serialization/CustomHostnameSslValidationErrorTest.cs
+++ b/CloudFlare.Client.Test/Serialization/CustomHostnameSslValidationErrorTest.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using CloudFlare.Client.Api.Zones.CustomHostnames;
+using CloudFlare.Client.Test.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace CloudFlare.Client.Test.Serialization;
+
+public class CustomHostnameSslValidationErrorTest
+{
+    [Fact]
+    public void TestSerialization()
+    {
+        var sut = new CustomHostnameSslValidationError();
+
+        JsonHelper.GetSerializedKeys(sut).Should().BeEquivalentTo(new SortedSet<string> { "message" });
+    }
+}

--- a/CloudFlare.Client.Test/Serialization/CustomHostnameSslValidationRecordTest.cs
+++ b/CloudFlare.Client.Test/Serialization/CustomHostnameSslValidationRecordTest.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using CloudFlare.Client.Api.Zones.CustomHostnames;
+using CloudFlare.Client.Test.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace CloudFlare.Client.Test.Serialization;
+
+public class CustomHostnameSslValidationRecordTest
+{
+    [Fact]
+    public void TestSerialization()
+    {
+        var sut = new CustomHostnameSslValidationRecord();
+
+        JsonHelper.GetSerializedKeys(sut).Should().BeEquivalentTo(new SortedSet<string> { "txt_name", "txt_value", "http_url", "http_body", "emails" });
+    }
+}

--- a/CloudFlare.Client.Test/Serialization/Enumerators/CustomHostnameStatusTest.cs
+++ b/CloudFlare.Client.Test/Serialization/Enumerators/CustomHostnameStatusTest.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using CloudFlare.Client.Enumerators;
+using CloudFlare.Client.Test.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace CloudFlare.Client.Test.Serialization.Enumerators
+{
+    public class CustomHostnameStatusTest
+    {
+        [Fact]
+        public void TestSerialization()
+        {
+            JsonHelper.GetSerializedEnums<CustomHostnameStatus>().Should().BeEquivalentTo(new SortedSet<string>
+            {
+                "active", "active_redeploying", "blocked", "deleted", "moved", "pending", "pending_blocked", "pending_deletion", "pending_migration", "pending_provisioned", "provisioned", "test_active", "test_active_apex", "test_blocked", "test_failed", "test_pending"
+            });
+        }
+    }
+}

--- a/CloudFlare.Client.Test/Serialization/Enumerators/StatusTest.cs
+++ b/CloudFlare.Client.Test/Serialization/Enumerators/StatusTest.cs
@@ -11,7 +11,7 @@ namespace CloudFlare.Client.Test.Serialization.Enumerators
         [Fact]
         public void TestSerialization()
         {
-            JsonHelper.GetSerializedEnums<Status>().Should().BeEquivalentTo(new SortedSet<string> { "accepted", "pending", "rejected" });
+            JsonHelper.GetSerializedEnums<MembershipStatus>().Should().BeEquivalentTo(new SortedSet<string> { "accepted", "pending", "rejected" });
         }
     }
 }

--- a/CloudFlare.Client.Test/Serialization/SslCertificateTest.cs
+++ b/CloudFlare.Client.Test/Serialization/SslCertificateTest.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using CloudFlare.Client.Api.Zones.CustomHostnames;
+using CloudFlare.Client.Test.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace CloudFlare.Client.Test.Serialization;
+
+public class SslCertificateTest
+{
+    [Fact]
+    public void TestSerialization()
+    {
+        var sut = new SslCertificate();
+
+        JsonHelper.GetSerializedKeys(sut).Should().BeEquivalentTo(new SortedSet<string>
+        {
+            "id", "issued_on", "expires_on", "uploaded_on", "issuer", "serial_number", "signature", "fingerprint_sha256"
+        });
+    }
+}

--- a/CloudFlare.Client.Test/Serialization/SslTest.cs
+++ b/CloudFlare.Client.Test/Serialization/SslTest.cs
@@ -15,7 +15,7 @@ namespace CloudFlare.Client.Test.Serialization
 
             JsonHelper.GetSerializedKeys(sut).Should().BeEquivalentTo(new SortedSet<string>
             {
-                "status", "method", "type", "cname_target", "cname", "settings"
+                "id", "status", "method", "type", "validation_records", "validation_errors", "hosts", "certificates", "cname_target", "cname", "certificate_authority", "bundle_method", "wildcard", "settings"
             });
         }
     }

--- a/CloudFlare.Client.Test/TestData/AccountMembershipTestData.cs
+++ b/CloudFlare.Client.Test/TestData/AccountMembershipTestData.cs
@@ -15,7 +15,7 @@ namespace CloudFlare.Client.Test.TestData
                 Code = "05dd05cce12bbed97c0d87cd78e89bc2fd41a6cee72f27f6fc84af2e45c0fac0",
                 User = UserTestData.Users.First(),
                 Roles = RoleTestData.Roles,
-                Status = Status.Accepted
+                Status = MembershipStatus.Accepted
             }
         };
     }

--- a/CloudFlare.Client.Test/TestData/CustomHostnameTestData.cs
+++ b/CloudFlare.Client.Test/TestData/CustomHostnameTestData.cs
@@ -20,7 +20,7 @@ namespace CloudFlare.Client.Test.TestData
                 CustomOriginServer = "origin",
                 OwnershipVerification = new OwnershipVerification { Name = "name", Type = "type", Value = Guid.NewGuid() },
                 OwnershipVerificationHttp = new OwnershipVerificationHttp { HttpBody = Guid.NewGuid(), HttpUrl = new Uri("http://www.tothnet.hu") },
-                Status = Status.Pending
+                Status = CustomHostnameStatus.Pending
             }
         };
     }

--- a/CloudFlare.Client.Test/TestData/UserMembershipTestsData.cs
+++ b/CloudFlare.Client.Test/TestData/UserMembershipTestsData.cs
@@ -16,7 +16,7 @@ namespace CloudFlare.Client.Test.TestData
                 Id = "4536bcfad5faccb111b47003c79917fa",
                 Permissions = PermissionTestData.Permissions,
                 Roles = new List<string> { "Account Administrator" },
-                Status = Status.Accepted
+                Status = MembershipStatus.Accepted
             }
         };
     }

--- a/CloudFlare.Client.Test/Users/MembershipUnitTests.cs
+++ b/CloudFlare.Client.Test/Users/MembershipUnitTests.cs
@@ -32,7 +32,7 @@ namespace CloudFlare.Client.Test.Users
         public async Task TestGetUserMembershipsAsync()
         {
             var displayOptions = new DisplayOptions { Page = 1, PerPage = 20, Order = OrderType.Asc };
-            var membershipFilter = new MembershipFilter { AccountName = "tothnet", MembershipOrder = MembershipOrder.Status, Status = Status.Accepted };
+            var membershipFilter = new MembershipFilter { AccountName = "tothnet", MembershipOrder = MembershipOrder.Status, Status = MembershipStatus.Accepted };
 
             _wireMockServer
                 .Given(Request.Create()
@@ -90,9 +90,9 @@ namespace CloudFlare.Client.Test.Users
 
             using var client = new CloudFlareClient(WireMockConnection.ApiKeyAuthentication, _connectionInfo);
 
-            var updateUserMembershipStatus = await client.Users.Memberships.UpdateAsync(membership.Id, Status.Pending);
+            var updateUserMembershipStatus = await client.Users.Memberships.UpdateAsync(membership.Id, MembershipStatus.Pending);
             updateUserMembershipStatus.Result.Should().BeEquivalentTo(membership, opt => opt.Excluding(x => x.Status));
-            updateUserMembershipStatus.Result.Status.Should().Be(Status.Pending);
+            updateUserMembershipStatus.Result.Status.Should().Be(MembershipStatus.Pending);
         }
 
         [Fact]

--- a/CloudFlare.Client/Api/Accounts/Member/Member.cs
+++ b/CloudFlare.Client/Api/Accounts/Member/Member.cs
@@ -27,7 +27,7 @@ namespace CloudFlare.Client.Api.Accounts.Member
         /// A member's status in the account
         /// </summary>
         [JsonProperty("status")]
-        public Status Status { get; set; }
+        public MembershipStatus Status { get; set; }
 
         /// <summary>
         /// User

--- a/CloudFlare.Client/Api/Accounts/Member/NewMember.cs
+++ b/CloudFlare.Client/Api/Accounts/Member/NewMember.cs
@@ -20,7 +20,7 @@ namespace CloudFlare.Client.Api.Accounts.Member
         /// A member's status in the account
         /// </summary>
         [JsonProperty("status")]
-        public Status Status { get; set; }
+        public MembershipStatus Status { get; set; }
 
         /// <summary>
         /// Array of roles associated with this member

--- a/CloudFlare.Client/Api/Users/Memberships/Membership.cs
+++ b/CloudFlare.Client/Api/Users/Memberships/Membership.cs
@@ -26,7 +26,7 @@ namespace CloudFlare.Client.Api.Users.Memberships
         /// A member's status in the account
         /// </summary>
         [JsonProperty("status")]
-        public Status Status { get; set; }
+        public MembershipStatus Status { get; set; }
 
         /// <summary>
         /// Membership entity object (Account/User)

--- a/CloudFlare.Client/Api/Users/Memberships/MembershipFilter.cs
+++ b/CloudFlare.Client/Api/Users/Memberships/MembershipFilter.cs
@@ -10,7 +10,7 @@ namespace CloudFlare.Client.Api.Users.Memberships
         /// <summary>
         /// Status of this membership
         /// </summary>
-        public Status? Status { get; set; }
+        public MembershipStatus? Status { get; set; }
 
         /// <summary>
         /// Account name

--- a/CloudFlare.Client/Api/Zones/CustomHostnames/CustomHostname.cs
+++ b/CloudFlare.Client/Api/Zones/CustomHostnames/CustomHostname.cs
@@ -44,7 +44,7 @@ namespace CloudFlare.Client.Api.Zones.CustomHostnames
         /// Status
         /// </summary>
         [JsonProperty("status")]
-        public Status Status { get; set; }
+        public CustomHostnameStatus Status { get; set; }
 
         /// <summary>
         /// Verification errors

--- a/CloudFlare.Client/Api/Zones/CustomHostnames/CustomHostname.cs
+++ b/CloudFlare.Client/Api/Zones/CustomHostnames/CustomHostname.cs
@@ -50,7 +50,7 @@ namespace CloudFlare.Client.Api.Zones.CustomHostnames
         /// Verification errors
         /// </summary>
         [JsonProperty("verification_errors")]
-        public IReadOnlyList<string> VerificationErrors { get; }
+        public IReadOnlyList<string> VerificationErrors { get; set; }
 
         /// <summary>
         /// Ownership verification

--- a/CloudFlare.Client/Api/Zones/CustomHostnames/CustomHostnameSslValidationError.cs
+++ b/CloudFlare.Client/Api/Zones/CustomHostnames/CustomHostnameSslValidationError.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace CloudFlare.Client.Api.Zones.CustomHostnames
+{
+    /// <summary>
+    /// These are errors that were encountered while trying to activate a hostname.
+    /// </summary>
+    public class CustomHostnameSslValidationError
+    {
+        /// <summary>
+        /// Validation error message
+        /// </summary>
+        [JsonProperty("message")]
+        public string Message { get; set; }
+    }
+}

--- a/CloudFlare.Client/Api/Zones/CustomHostnames/CustomHostnameSslValidationRecord.cs
+++ b/CloudFlare.Client/Api/Zones/CustomHostnames/CustomHostnameSslValidationRecord.cs
@@ -1,0 +1,40 @@
+﻿using Newtonsoft.Json;
+
+namespace CloudFlare.Client.Api.Zones.CustomHostnames
+{
+    /// <summary>
+    /// Control validation records
+    /// </summary>
+    public class CustomHostnameSslValidationRecord
+    {
+        /// <summary>
+        /// TxtName
+        /// </summary>
+        [JsonProperty("txt_name")]
+        public string TxtName { get; set; }
+
+        /// <summary>
+        /// TxtValue
+        /// </summary>
+        [JsonProperty("txt_value")]
+        public string TxtValue { get; set; }
+
+        /// <summary>
+        /// HttpUrl
+        /// </summary>
+        [JsonProperty("http_url")]
+        public string HttpUrl { get; set; }
+
+        /// <summary>
+        /// HttpBody
+        /// </summary>
+        [JsonProperty("http_body")]
+        public string HttpBody { get; set; }
+
+        /// <summary>
+        /// Emails
+        /// </summary>
+        [JsonProperty("emails")]
+        public string[] Emails { get; set; }
+    }
+}

--- a/CloudFlare.Client/Api/Zones/CustomHostnames/Ssl.cs
+++ b/CloudFlare.Client/Api/Zones/CustomHostnames/Ssl.cs
@@ -9,6 +9,12 @@ namespace CloudFlare.Client.Api.Zones.CustomHostnames
     public class Ssl
     {
         /// <summary>
+        /// Id
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
         /// Status of the hostname's SSL certificates
         /// </summary>
         [JsonProperty("status")]
@@ -27,6 +33,30 @@ namespace CloudFlare.Client.Api.Zones.CustomHostnames
         public DomainValidationType Type { get; set; }
 
         /// <summary>
+        /// ValidationRecords
+        /// </summary>
+        [JsonProperty("validation_records")]
+        public CustomHostnameSslValidationRecord[] ValidationRecords { get; set; }
+
+        /// <summary>
+        /// ValidationErrors
+        /// </summary>
+        [JsonProperty("validation_errors")]
+        public CustomHostnameSslValidationError[] ValidationErrors { get; set; }
+
+        /// <summary>
+        /// Hosts
+        /// </summary>
+        [JsonProperty("hosts")]
+        public string[] Hosts { get; set; }
+
+        /// <summary>
+        /// Certificates
+        /// </summary>
+        [JsonProperty("certificates")]
+        public SslCertificate[] Certificates { get; set; }
+
+        /// <summary>
         /// The value that must be returned when the CNAME (cname) is queried during domain validation
         /// </summary>
         [JsonProperty("cname_target")]
@@ -37,6 +67,24 @@ namespace CloudFlare.Client.Api.Zones.CustomHostnames
         /// </summary>
         [JsonProperty("cname")]
         public string Cname { get; set; }
+
+        /// <summary>
+        /// CertificateAuthority
+        /// </summary>
+        [JsonProperty("certificate_authority")]
+        public string CertificateAuthority { get; set; }
+
+        /// <summary>
+        /// BundleMethod
+        /// </summary>
+        [JsonProperty("bundle_method")]
+        public string BundleMethod { get; set; }
+
+        /// <summary>
+        /// Wildcard
+        /// </summary>
+        [JsonProperty("wildcard")]
+        public bool Wildcard { get; set; }
 
         /// <summary>
         /// Additional SSL specific settings

--- a/CloudFlare.Client/Api/Zones/CustomHostnames/Ssl.cs
+++ b/CloudFlare.Client/Api/Zones/CustomHostnames/Ssl.cs
@@ -9,7 +9,7 @@ namespace CloudFlare.Client.Api.Zones.CustomHostnames
     public class Ssl
     {
         /// <summary>
-        /// Id
+        /// SSL identifier tag
         /// </summary>
         [JsonProperty("id")]
         public string Id { get; set; }
@@ -33,19 +33,19 @@ namespace CloudFlare.Client.Api.Zones.CustomHostnames
         public DomainValidationType Type { get; set; }
 
         /// <summary>
-        /// ValidationRecords
+        /// Certificate's required validation records
         /// </summary>
         [JsonProperty("validation_records")]
         public CustomHostnameSslValidationRecord[] ValidationRecords { get; set; }
 
         /// <summary>
-        /// ValidationErrors
+        /// Certificate's validation errors
         /// </summary>
         [JsonProperty("validation_errors")]
         public CustomHostnameSslValidationError[] ValidationErrors { get; set; }
 
         /// <summary>
-        /// Hosts
+        /// The valid hosts for the certificate
         /// </summary>
         [JsonProperty("hosts")]
         public string[] Hosts { get; set; }
@@ -69,19 +69,21 @@ namespace CloudFlare.Client.Api.Zones.CustomHostnames
         public string Cname { get; set; }
 
         /// <summary>
-        /// CertificateAuthority
+        /// The Certificate Authority that has issued this certificate
         /// </summary>
         [JsonProperty("certificate_authority")]
         public string CertificateAuthority { get; set; }
 
         /// <summary>
-        /// BundleMethod
+        /// A ubiquitous bundle has the highest probability of being verified everywhere, even by clients using outdated or unusual trust stores.
+        /// An optimal bundle uses the shortest chain and newest intermediates.
+        /// And the force bundle verifies the chain, but does not otherwise modify it.
         /// </summary>
         [JsonProperty("bundle_method")]
         public string BundleMethod { get; set; }
 
         /// <summary>
-        /// Wildcard
+        /// Indicates whether the certificate covers a wildcard
         /// </summary>
         [JsonProperty("wildcard")]
         public bool Wildcard { get; set; }

--- a/CloudFlare.Client/Api/Zones/CustomHostnames/SslCertificate.cs
+++ b/CloudFlare.Client/Api/Zones/CustomHostnames/SslCertificate.cs
@@ -9,49 +9,49 @@ namespace CloudFlare.Client.Api.Zones.CustomHostnames
     public class SslCertificate
     {
         /// <summary>
-        /// Id
+        /// Custom hostname SSL identifier tag
         /// </summary>
         [JsonProperty("id")]
         public string Id { get; set; }
 
         /// <summary>
-        /// IssuedOn
+        /// The time on which the custom certificate was created
         /// </summary>
         [JsonProperty("issued_on")]
         public DateTime? IssuedOn { get; set; }
 
         /// <summary>
-        /// ExpiresOn
+        /// The time the custom certificate expires on
         /// </summary>
         [JsonProperty("expires_on")]
         public DateTime? ExpiresOn { get; set; }
 
         /// <summary>
-        /// UploadedOn
+        /// The time the custom certificate was uploaded
         /// </summary>
         [JsonProperty("uploaded_on")]
         public DateTime? UploadedOn { get; set; }
 
         /// <summary>
-        /// Issuer
+        /// The issuer on a custom uploaded certificate
         /// </summary>
         [JsonProperty("issuer")]
         public string Issuer { get; set; }
 
         /// <summary>
-        /// SerialNumber
+        /// The serial number on a custom uploaded certificate
         /// </summary>
         [JsonProperty("serial_number")]
         public string SerialNumber { get; set; }
 
         /// <summary>
-        /// Signature
+        /// The signature on a custom uploaded certificate
         /// </summary>
         [JsonProperty("signature")]
         public string Signature { get; set; }
 
         /// <summary>
-        /// FingerprintSha256
+        /// The SHA256 fingerprint on a custom uploaded certificate
         /// </summary>
         [JsonProperty("fingerprint_sha256")]
         public string FingerprintSha256 { get; set; }

--- a/CloudFlare.Client/Api/Zones/CustomHostnames/SslCertificate.cs
+++ b/CloudFlare.Client/Api/Zones/CustomHostnames/SslCertificate.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace CloudFlare.Client.Api.Zones.CustomHostnames
+{
+    /// <summary>
+    /// SslCertificate
+    /// </summary>
+    public class SslCertificate
+    {
+        /// <summary>
+        /// Id
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// IssuedOn
+        /// </summary>
+        [JsonProperty("issued_on")]
+        public DateTime? IssuedOn { get; set; }
+
+        /// <summary>
+        /// ExpiresOn
+        /// </summary>
+        [JsonProperty("expires_on")]
+        public DateTime? ExpiresOn { get; set; }
+
+        /// <summary>
+        /// UploadedOn
+        /// </summary>
+        [JsonProperty("uploaded_on")]
+        public DateTime? UploadedOn { get; set; }
+
+        /// <summary>
+        /// Issuer
+        /// </summary>
+        [JsonProperty("issuer")]
+        public string Issuer { get; set; }
+
+        /// <summary>
+        /// SerialNumber
+        /// </summary>
+        [JsonProperty("serial_number")]
+        public string SerialNumber { get; set; }
+
+        /// <summary>
+        /// Signature
+        /// </summary>
+        [JsonProperty("signature")]
+        public string Signature { get; set; }
+
+        /// <summary>
+        /// FingerprintSha256
+        /// </summary>
+        [JsonProperty("fingerprint_sha256")]
+        public string FingerprintSha256 { get; set; }
+    }
+}

--- a/CloudFlare.Client/Client/Users/IMemberships.cs
+++ b/CloudFlare.Client/Client/Users/IMemberships.cs
@@ -45,6 +45,6 @@ namespace CloudFlare.Client.Client.Users
         /// <param name="status">Whether to accept or reject this account invitation</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The updated membership</returns>
-        Task<CloudFlareResult<Membership>> UpdateAsync(string membershipId, Status status, CancellationToken cancellationToken = default);
+        Task<CloudFlareResult<Membership>> UpdateAsync(string membershipId, MembershipStatus status, CancellationToken cancellationToken = default);
     }
 }

--- a/CloudFlare.Client/Client/Users/Memberships.cs
+++ b/CloudFlare.Client/Client/Users/Memberships.cs
@@ -61,15 +61,15 @@ namespace CloudFlare.Client.Client.Users
         }
 
         /// <inheritdoc />
-        public async Task<CloudFlareResult<Membership>> UpdateAsync(string membershipId, Status status, CancellationToken cancellationToken = default)
+        public async Task<CloudFlareResult<Membership>> UpdateAsync(string membershipId, MembershipStatus status, CancellationToken cancellationToken = default)
         {
-            var data = new Dictionary<string, Status>
+            var data = new Dictionary<string, MembershipStatus>
             {
                 { Filtering.Status, status }
             };
 
             var requestUri = $"{MembershipEndpoints.Base}/{membershipId}";
-            return await Connection.PutAsync<Membership, Dictionary<string, Status>>(requestUri, data, cancellationToken).ConfigureAwait(false);
+            return await Connection.PutAsync<Membership, Dictionary<string, MembershipStatus>>(requestUri, data, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/CloudFlare.Client/Enumerators/CustomHostnameStatus.cs
+++ b/CloudFlare.Client/Enumerators/CustomHostnameStatus.cs
@@ -1,0 +1,109 @@
+﻿using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace CloudFlare.Client.Enumerators
+{
+    /// <summary>
+    /// Status of the hostname's activation
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum CustomHostnameStatus
+    {
+        /// <summary>
+        /// Active
+        /// </summary>
+        [EnumMember(Value = "active")]
+        Active,
+
+        /// <summary>
+        /// Pending
+        /// </summary>
+        [EnumMember(Value = "pending")]
+        Pending,
+
+        /// <summary>
+        /// ActiveRedeploying
+        /// </summary>
+        [EnumMember(Value = "active_redeploying")]
+        ActiveRedeploying,
+
+        /// <summary>
+        /// Moved
+        /// </summary>
+        [EnumMember(Value = "moved")]
+        Moved,
+
+        /// <summary>
+        /// PendingDeletion
+        /// </summary>
+        [EnumMember(Value = "pending_deletion")]
+        PendingDeletion,
+
+        /// <summary>
+        /// Deleted
+        /// </summary>
+        [EnumMember(Value = "deleted")]
+        Deleted,
+
+        /// <summary>
+        /// PendingBlocked
+        /// </summary>
+        [EnumMember(Value = "pending_blocked")]
+        PendingBlocked,
+
+        /// <summary>
+        /// PendingMigration
+        /// </summary>
+        [EnumMember(Value = "pending_migration")]
+        PendingMigration,
+
+        /// <summary>
+        /// PendingProvisioned
+        /// </summary>
+        [EnumMember(Value = "pending_provisioned")]
+        PendingProvisioned,
+
+        /// <summary>
+        /// TestPending
+        /// </summary>
+        [EnumMember(Value = "test_pending")]
+        TestPending,
+
+        /// <summary>
+        /// TestActive
+        /// </summary>
+        [EnumMember(Value = "test_active")]
+        TestActive,
+
+        /// <summary>
+        /// TestActiveApex
+        /// </summary>
+        [EnumMember(Value = "test_active_apex")]
+        TestActiveApex,
+
+        /// <summary>
+        /// TestBlocked
+        /// </summary>
+        [EnumMember(Value = "test_blocked")]
+        TestBlocked,
+
+        /// <summary>
+        /// TestFailed
+        /// </summary>
+        [EnumMember(Value = "test_failed")]
+        TestFailed,
+
+        /// <summary>
+        /// Provisioned
+        /// </summary>
+        [EnumMember(Value = "provisioned")]
+        Provisioned,
+
+        /// <summary>
+        /// Blocked
+        /// </summary>
+        [EnumMember(Value = "blocked")]
+        Blocked
+    }
+}

--- a/CloudFlare.Client/Enumerators/MembershipStatus.cs
+++ b/CloudFlare.Client/Enumerators/MembershipStatus.cs
@@ -8,7 +8,7 @@ namespace CloudFlare.Client.Enumerators
     /// Status of this membership
     /// </summary>
     [JsonConverter(typeof(StringEnumConverter))]
-    public enum Status
+    public enum MembershipStatus
     {
         /// <summary>
         /// Accepted


### PR DESCRIPTION
Missing some statuses - can't list my hostnames as they're mostly in an "active" state which isn't a listed value of the current enum so it just throws an exception

![image](https://user-images.githubusercontent.com/1546181/184467306-2db29b4b-265e-4226-bb10-a4a28d74c96f.png)

missing setter yields null on deserialization:
![image](https://user-images.githubusercontent.com/1546181/184468589-fbe31ef0-a2dc-4ecc-9b70-e49d75e9ed4b.png)

added a number of additional properties- Cloudflare API docs seem to be incorrect vs actual API responses - started by modeling against docs then had to pivot hierarchy to reflect levels where properties actually exist.
