### PR TITLE
Add extension method to fetch all the results

### DIFF
--- a/CloudFlare.Client.Test/Certificates/CertificatesUnitTests.cs
+++ b/CloudFlare.Client.Test/Certificates/CertificatesUnitTests.cs
@@ -1,0 +1,110 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using CloudFlare.Client.Api.Certificates;
+using CloudFlare.Client.Api.Display;
+using CloudFlare.Client.Api.Parameters;
+using CloudFlare.Client.Api.Parameters.Endpoints;
+using CloudFlare.Client.Contexts;
+using CloudFlare.Client.Enumerators;
+using CloudFlare.Client.Test.Helpers;
+using CloudFlare.Client.Test.TestData;
+using FluentAssertions;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+using Xunit;
+
+namespace CloudFlare.Client.Test.Certificates
+{
+    public class CertificatesUnitTests
+    {
+        private readonly WireMockServer _wireMockServer;
+        private readonly ConnectionInfo _connectionInfo;
+
+        public CertificatesUnitTests()
+        {
+            _wireMockServer = WireMockServer.Start();
+            _connectionInfo = new WireMockConnection(_wireMockServer.Urls.First()).ConnectionInfo;
+        }
+
+        [Fact]
+        public async Task TestCreateCertificateAsync()
+        {
+            var certificates = CertificatesTestData.Certificates.First();
+            var certificate = new NewCertificate
+            {
+                CertificateSigningRequest = "",
+                Hostnames = certificates.Hostnames
+            };
+
+            _wireMockServer
+                .Given(Request.Create().WithPath($"/{CertificateEndpoints.Base}").UsingPost())
+                .RespondWith(Response.Create().WithStatusCode(200)
+                    .WithBody(WireMockResponseHelper.CreateTestResponse(certificates)));
+
+            using var client = new CloudFlareClient(WireMockConnection.ApiKeyAuthentication, _connectionInfo);
+
+            var addCertificate = await client.Certificates.AddAsync(certificate);
+
+            addCertificate.Result.Should().BeEquivalentTo(certificates);
+        }
+
+        [Fact]
+        public async Task TestGetCertificatesAsync()
+        {
+            var displayOptions = new DisplayOptions { Page = 1, PerPage = 20, Order = OrderType.Asc };
+
+            _wireMockServer
+                .Given(Request.Create()
+                    .WithPath($"/{CertificateEndpoints.Base}/")
+                    .WithParam(Filtering.ZoneId)
+                    .UsingGet())
+                .RespondWith(Response.Create().WithStatusCode(200)
+                    .WithBody(WireMockResponseHelper.CreateTestResponse(CertificatesTestData.Certificates)));
+
+            using var client = new CloudFlareClient(WireMockConnection.ApiKeyAuthentication, _connectionInfo);
+
+            var certificates = await client.Certificates.GetAsync("023e105f4ecef8ad9ca31a8372d0c353", displayOptions);
+
+            certificates.Result.Should().BeEquivalentTo(CertificatesTestData.Certificates);
+        }
+
+        [Fact]
+        public async Task TestGetCertificateDetailsAsync()
+        {
+            var certificate = CertificatesTestData.Certificates.First();
+
+            _wireMockServer
+                .Given(Request.Create().WithPath($"/{CertificateEndpoints.Base}/{certificate.Id}").UsingGet())
+                .RespondWith(Response.Create().WithStatusCode(200)
+                    .WithBody(WireMockResponseHelper.CreateTestResponse(certificate)));
+
+            using var client = new CloudFlareClient(WireMockConnection.ApiKeyAuthentication, _connectionInfo);
+
+            var certificateDetails = await client.Certificates.GetDetailsAsync(certificate.Id);
+
+            certificateDetails.Result.Should().BeEquivalentTo(certificate);
+        }
+
+        [Fact]
+        public async Task TestRevocationCertificateAsync()
+        {
+            var certificate = CertificatesTestData.Certificates.First();
+            var revokeCertificate = new RevokedCertificate
+            {
+                Id = certificate.Id
+            };
+
+            _wireMockServer
+                .Given(Request.Create().WithPath($"/{CertificateEndpoints.Base}/{certificate.Id}").UsingDelete())
+                .RespondWith(Response.Create().WithStatusCode(200)
+                    .WithBody(WireMockResponseHelper.CreateTestResponse(certificate)));
+
+            using var client = new CloudFlareClient(WireMockConnection.ApiKeyAuthentication, _connectionInfo);
+
+            var revocationCertificate = await client.Certificates.RevokeAsync(certificate.Id);
+
+            revocationCertificate.Result.Should().BeEquivalentTo(revokeCertificate);
+        }
+    }
+}

--- a/CloudFlare.Client.Test/Helpers/WireMockResponseHelper.cs
+++ b/CloudFlare.Client.Test/Helpers/WireMockResponseHelper.cs
@@ -16,5 +16,16 @@ namespace CloudFlare.Client.Test.Helpers
                 CommonTestData.ApiErrors,
                 CommonTestData.TimingInfo));
         }
+
+        public static string CreateTestResponse<T>(T item, ResultInfo resultInfo)
+        {
+            return JsonConvert.SerializeObject(new CloudFlareResult<T>(
+                item,
+                resultInfo,
+                true,
+                CommonTestData.ErrorDetails,
+                CommonTestData.ApiErrors,
+                CommonTestData.TimingInfo));
+        }
     }
 }

--- a/CloudFlare.Client.Test/TestData/CertificatesTestData.cs
+++ b/CloudFlare.Client.Test/TestData/CertificatesTestData.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using CloudFlare.Client.Api.Certificates;
+
+namespace CloudFlare.Client.Test.TestData
+{
+    public class CertificatesTestData
+    {
+        public static List<Certificate> Certificates { get; set; } = new()
+        {
+            new Certificate
+            {
+                OriginCertificate = "",
+                CertificateSigningRequest = "",
+                Id = "023e105f4ecef8ad9ca31a8372d0c353",
+                Hostnames = new List<string> { "tothnet.hu", "*.tothnet.hu" },
+                ExpiresOn = new System.DateTime(2050, 1, 1),
+                RequestedValidity = 5475,
+                RequestType = Enumerators.CertificateType.OriginRsa,
+            }
+        };
+    }
+}

--- a/CloudFlare.Client/Api/Certificates/Certificate.cs
+++ b/CloudFlare.Client/Api/Certificates/Certificate.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using CloudFlare.Client.Enumerators;
+using CloudFlare.Client.Helpers;
+using Newtonsoft.Json;
+
+namespace CloudFlare.Client.Api.Certificates
+{
+    /// <summary>
+    /// Certificate
+    /// </summary>
+    public class Certificate
+    {
+        /// <summary>
+        /// The Origin CA certificate. Will be newline-encoded.
+        /// </summary>
+        [JsonProperty("certificate")]
+        public string OriginCertificate { get; set; }
+
+        /// <summary>
+        /// The Certificate Signing Request (CSR). Must be newline-encoded.
+        /// </summary>
+        [JsonProperty("csr")]
+        public string CertificateSigningRequest { get; set; }
+
+        /// <summary>
+        /// When the certificate will expire.
+        /// </summary>
+        [JsonProperty("expires_on")]
+        [JsonConverter(typeof(CertificateExpiresOnConverter))]
+        public DateTime? ExpiresOn { get; set; }
+
+        /// <summary>
+        /// List of hostnames or wildcard names (e.g., *.example.com) bound to the certificate.
+        /// </summary>
+        [JsonProperty("hostnames")]
+        public IReadOnlyList<string> Hostnames { get; set; }
+
+        /// <summary>
+        /// Unique identifier for the certificate.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Signature type desired on certificate.
+        /// </summary>
+        [JsonProperty("request_type")]
+        public CertificateType RequestType { get; set; }
+
+        /// <summary>
+        /// The number of days for which the certificate should be valid.
+        /// </summary>
+        [JsonProperty("requested_validity")]
+        public int RequestedValidity { get; set; }
+    }
+}

--- a/CloudFlare.Client/Api/Certificates/NewCertificate.cs
+++ b/CloudFlare.Client/Api/Certificates/NewCertificate.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using CloudFlare.Client.Enumerators;
+using Newtonsoft.Json;
+
+namespace CloudFlare.Client.Api.Certificates
+{
+    /// <summary>
+    /// Certificate
+    /// </summary>
+    public class NewCertificate
+    {
+        /// <summary>
+        /// The Certificate Signing Request (CSR). Must be newline-encoded.
+        /// </summary>
+        [JsonProperty("csr")]
+        public string CertificateSigningRequest { get; set; }
+
+        /// <summary>
+        /// List of hostnames or wildcard names (e.g., *.example.com) bound to the certificate.
+        /// </summary>
+        [JsonProperty("hostnames")]
+        public IReadOnlyList<string> Hostnames { get; set; }
+
+        /// <summary>
+        /// Signature type desired on certificate.
+        /// </summary>
+        [JsonProperty("request_type")]
+        public CertificateType RequestType { get; set; }
+
+        /// <summary>
+        /// The number of days for which the certificate should be valid.
+        /// </summary>
+        [JsonProperty("requested_validity")]
+        public int? RequestedValidity { get; set; }
+    }
+}

--- a/CloudFlare.Client/Api/Certificates/RevokedCertificate.cs
+++ b/CloudFlare.Client/Api/Certificates/RevokedCertificate.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace CloudFlare.Client.Api.Certificates
+{
+    /// <summary>
+    /// Certificate
+    /// </summary>
+    public class RevokedCertificate
+    {
+        /// <summary>
+        /// Unique identifier for the certificate.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+    }
+}

--- a/CloudFlare.Client/Api/Parameters/Endpoints/CertificateEndpoints.cs
+++ b/CloudFlare.Client/Api/Parameters/Endpoints/CertificateEndpoints.cs
@@ -1,0 +1,7 @@
+﻿namespace CloudFlare.Client.Api.Parameters.Endpoints
+{
+    internal static class CertificateEndpoints
+    {
+        public const string Base = "certificates";
+    }
+}

--- a/CloudFlare.Client/Api/Parameters/Filtering.cs
+++ b/CloudFlare.Client/Api/Parameters/Filtering.cs
@@ -99,5 +99,10 @@
         /// Status representation on CloudFlare
         /// </summary>
         public const string Status = "status";
+
+        /// <summary>
+        /// ZoneId representation on CloudFlare
+        /// </summary>
+        public const string ZoneId = "zone_id";
     }
 }

--- a/CloudFlare.Client/Client/Accounts/IAccounts.cs
+++ b/CloudFlare.Client/Client/Accounts/IAccounts.cs
@@ -10,7 +10,7 @@ namespace CloudFlare.Client.Client.Accounts
     /// <summary>
     /// Interface for interacting with accounts
     /// </summary>
-    public interface IAccounts
+    public interface IAccounts : IGetApi<DisplayOptions, Account>
     {
         /// <summary>
         /// Members
@@ -42,7 +42,7 @@ namespace CloudFlare.Client.Client.Accounts
         /// <param name="displayOptions">Display options</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The requested account</returns>
-        Task<CloudFlareResult<IReadOnlyList<Account>>> GetAsync(DisplayOptions displayOptions = null, CancellationToken cancellationToken = default);
+        new Task<CloudFlareResult<IReadOnlyList<Account>>> GetAsync(DisplayOptions displayOptions = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get information about a specific account that you are a member of

--- a/CloudFlare.Client/Client/Accounts/IMembers.cs
+++ b/CloudFlare.Client/Client/Accounts/IMembers.cs
@@ -10,7 +10,7 @@ namespace CloudFlare.Client.Client.Accounts
     /// <summary>
     /// Interface for interacting with members
     /// </summary>
-    public interface IMembers
+    public interface IMembers : IGetApi<string, DisplayOptions, Member>
     {
         /// <summary>
         /// Add a user to the list of members for this account
@@ -37,7 +37,7 @@ namespace CloudFlare.Client.Client.Accounts
         /// <param name="displayOptions">Display Options</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The requested member</returns>
-        Task<CloudFlareResult<IReadOnlyList<Member>>> GetAsync(string accountId, DisplayOptions displayOptions = null, CancellationToken cancellationToken = default);
+        new Task<CloudFlareResult<IReadOnlyList<Member>>> GetAsync(string accountId, DisplayOptions displayOptions = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get information about a specific member of an account

--- a/CloudFlare.Client/Client/Certificates/Certificates.cs
+++ b/CloudFlare.Client/Client/Certificates/Certificates.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CloudFlare.Client.Api.Certificates;
+using CloudFlare.Client.Api.Display;
+using CloudFlare.Client.Api.Parameters;
+using CloudFlare.Client.Api.Parameters.Endpoints;
+using CloudFlare.Client.Api.Result;
+using CloudFlare.Client.Contexts;
+using CloudFlare.Client.Enumerators;
+using CloudFlare.Client.Helpers;
+
+namespace CloudFlare.Client.Client.Certificates
+{
+    /// <inheritdoc cref="ICertificates"/>
+    public class Certificates : ApiContextBase<IConnection>, ICertificates
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Certificates"/> class
+        /// </summary>
+        /// <param name="connection">Connection settings</param>
+        public Certificates(IConnection connection)
+            : base(connection)
+        {
+        }
+
+        /// <inheritdoc />
+        public async Task<CloudFlareResult<IReadOnlyList<Certificate>>> GetAsync(string zoneId, UnOrderableDisplayOptions displayOptions = null, CancellationToken cancellationToken = default)
+        {
+            var builder = new ParameterBuilderHelper()
+                .InsertValue(Filtering.Page, displayOptions?.Page)
+                .InsertValue(Filtering.PerPage, displayOptions?.PerPage)
+                .InsertValue(Filtering.ZoneId, zoneId);
+
+            var requestUri = $"{CertificateEndpoints.Base}";
+
+            if (builder.ParameterCollection.HasKeys())
+            {
+                requestUri = $"{requestUri}/?{builder.ParameterCollection}";
+            }
+
+            return await Connection.GetAsync<IReadOnlyList<Certificate>>(requestUri, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public Task<CloudFlareResult<Certificate>> GetDetailsAsync(string certificateId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"{CertificateEndpoints.Base}/{certificateId}";
+            return Connection.GetAsync<Certificate>(requestUri, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task<CloudFlareResult<Certificate>> AddAsync(
+            NewCertificate newCertificate,
+            CancellationToken cancellationToken = default)
+        {
+            return Connection.PostAsync<Certificate, NewCertificate>(CertificateEndpoints.Base, newCertificate, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task<CloudFlareResult<RevokedCertificate>> RevokeAsync(string certificateId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"{CertificateEndpoints.Base}/{certificateId}";
+            return Connection.DeleteAsync<RevokedCertificate>(requestUri, cancellationToken);
+        }
+    }
+}

--- a/CloudFlare.Client/Client/Certificates/ICertificates.cs
+++ b/CloudFlare.Client/Client/Certificates/ICertificates.cs
@@ -4,14 +4,13 @@ using System.Threading.Tasks;
 using CloudFlare.Client.Api.Certificates;
 using CloudFlare.Client.Api.Display;
 using CloudFlare.Client.Api.Result;
-using CloudFlare.Client.Enumerators;
 
 namespace CloudFlare.Client.Client.Certificates
 {
     /// <summary>
     /// Interface for interacting with certificates
     /// </summary>
-    public interface ICertificates
+    public interface ICertificates : IGetApi<string, UnOrderableDisplayOptions, Certificate>
     {
         /// <summary>
         /// Get all certificates
@@ -20,7 +19,7 @@ namespace CloudFlare.Client.Client.Certificates
         /// <param name="displayOptions">Display options</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A list of all certificates</returns>
-        Task<CloudFlareResult<IReadOnlyList<Certificate>>> GetAsync(string zoneId, UnOrderableDisplayOptions displayOptions = null, CancellationToken cancellationToken = default);
+        new Task<CloudFlareResult<IReadOnlyList<Certificate>>> GetAsync(string zoneId, UnOrderableDisplayOptions displayOptions = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a certificate

--- a/CloudFlare.Client/Client/Certificates/ICertificates.cs
+++ b/CloudFlare.Client/Client/Certificates/ICertificates.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CloudFlare.Client.Api.Certificates;
+using CloudFlare.Client.Api.Display;
+using CloudFlare.Client.Api.Result;
+using CloudFlare.Client.Enumerators;
+
+namespace CloudFlare.Client.Client.Certificates
+{
+    /// <summary>
+    /// Interface for interacting with certificates
+    /// </summary>
+    public interface ICertificates
+    {
+        /// <summary>
+        /// Get all certificates
+        /// </summary>
+        /// <param name="zoneId">The zone id</param>
+        /// <param name="displayOptions">Display options</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of all certificates</returns>
+        Task<CloudFlareResult<IReadOnlyList<Certificate>>> GetAsync(string zoneId, UnOrderableDisplayOptions displayOptions = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get a certificate
+        /// </summary>
+        /// <param name="certificateId">The certificate id</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>The certificate</returns>
+        Task<CloudFlareResult<Certificate>> GetDetailsAsync(string certificateId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Create an Origin CA certificate.
+        /// </summary>
+        /// <param name="newCertificate">The new certificate</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>The created certificate</returns>
+        Task<CloudFlareResult<Certificate>> AddAsync(NewCertificate newCertificate, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Revoke a certificate
+        /// </summary>
+        /// <param name="certificateId">The certificate id</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>The revoked certificate</returns>
+        Task<CloudFlareResult<RevokedCertificate>> RevokeAsync(string certificateId, CancellationToken cancellationToken = default);
+    }
+}

--- a/CloudFlare.Client/Client/IGetApi.cs
+++ b/CloudFlare.Client/Client/IGetApi.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CloudFlare.Client.Api.Display;
+using CloudFlare.Client.Api.Result;
+using CloudFlare.Client.Api.Zones;
+
+namespace CloudFlare.Client.Client;
+
+/// <summary>
+/// Interface for fetching data from CloudFlare
+/// </summary>
+/// <typeparam name="TDisplayOptions">Display options</typeparam>
+/// <typeparam name="TResult">Result type</typeparam>
+public interface IGetApi<in TDisplayOptions, TResult>
+    where TDisplayOptions : UnOrderableDisplayOptions
+{
+    /// <summary>
+    /// List, search, sort, and filter
+    /// </summary>
+    /// <param name="displayOptions">Display options</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The result set</returns>
+    Task<CloudFlareResult<IReadOnlyList<TResult>>> GetAsync(TDisplayOptions displayOptions = null, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Interface for fetching data from CloudFlare
+/// </summary>
+/// <typeparam name="TFilter">Filtering options</typeparam>
+/// <typeparam name="TDisplayOptions">Display options</typeparam>
+/// <typeparam name="TResult">Result type</typeparam>
+public interface IGetApi<in TFilter, in TDisplayOptions, TResult>
+    where TFilter : class
+    where TDisplayOptions : UnOrderableDisplayOptions
+{
+    /// <summary>
+    /// List, search, sort, and filter
+    /// </summary>
+    /// <param name="filter">Filtering options</param>
+    /// <param name="displayOptions">Display options</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The result set</returns>
+    Task<CloudFlareResult<IReadOnlyList<TResult>>> GetAsync(TFilter filter = null, TDisplayOptions displayOptions = null, CancellationToken cancellationToken = default);
+}

--- a/CloudFlare.Client/Client/Zones/IZones.cs
+++ b/CloudFlare.Client/Client/Zones/IZones.cs
@@ -10,7 +10,7 @@ namespace CloudFlare.Client.Client.Zones
     /// <summary>
     /// Interface for interacting with zones
     /// </summary>
-    public interface IZones
+    public interface IZones : IGetApi<ZoneFilter, DisplayOptions, Zone>
     {
         /// <summary>
         /// Custom hostnames
@@ -79,7 +79,7 @@ namespace CloudFlare.Client.Client.Zones
         /// <param name="displayOptions">Display options</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The requested zones</returns>
-        Task<CloudFlareResult<IReadOnlyList<Zone>>> GetAsync(ZoneFilter filter = null, DisplayOptions displayOptions = null, CancellationToken cancellationToken = default);
+        new Task<CloudFlareResult<IReadOnlyList<Zone>>> GetAsync(ZoneFilter filter = null, DisplayOptions displayOptions = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get all details of the specified zone

--- a/CloudFlare.Client/CloudFlareClient.cs
+++ b/CloudFlare.Client/CloudFlareClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using CloudFlare.Client.Api.Authentication;
 using CloudFlare.Client.Client.Accounts;
+using CloudFlare.Client.Client.Certificates;
 using CloudFlare.Client.Client.Users;
 using CloudFlare.Client.Client.Zones;
 using CloudFlare.Client.Contexts;
@@ -26,6 +27,7 @@ namespace CloudFlare.Client
             Accounts = new Accounts(_connection);
             Users = new Users(_connection);
             Zones = new Zones(_connection);
+            Certificates = new Certificates(_connection);
         }
 
         /// <summary>
@@ -65,6 +67,9 @@ namespace CloudFlare.Client
 
         /// <inheritdoc />
         public IZones Zones { get; }
+
+        /// <inheritdoc />
+        public ICertificates Certificates { get; }
 
         /// <summary>
         /// Whether the <see cref="CloudFlareClient"/> is disposed

--- a/CloudFlare.Client/Enumerators/CertificateType.cs
+++ b/CloudFlare.Client/Enumerators/CertificateType.cs
@@ -1,0 +1,31 @@
+﻿using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace CloudFlare.Client.Enumerators
+{
+    /// <summary>
+    /// Signature type desired on certificate.
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum CertificateType
+    {
+        /// <summary>
+        /// Origin RSA.
+        /// </summary>
+        [EnumMember(Value = "origin-rsa")]
+        OriginRsa,
+
+        /// <summary>
+        /// Origin ECC.
+        /// </summary>
+        [EnumMember(Value = "origin-ecc")]
+        OriginEcc,
+
+        /// <summary>
+        /// Custom RSA.
+        /// </summary>
+        [EnumMember(Value = "custom-rsa")]
+        KeylessCertificate
+    }
+}

--- a/CloudFlare.Client/Extensions/GetExtensions.cs
+++ b/CloudFlare.Client/Extensions/GetExtensions.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CloudFlare.Client.Api.Display;
+using CloudFlare.Client.Api.Result;
+using CloudFlare.Client.Client;
+
+namespace CloudFlare.Client.Extensions;
+
+/// <summary>
+/// Extensions for <see cref="IGetApi{TDisplayOptions,TResult}"/> and <see cref="IGetApi{TFilter,TDisplayOptions,TResult}"/>.
+/// </summary>
+public static class GetExtensions
+{
+    /// <summary>
+    /// Get all results from all the pages.
+    /// </summary>
+    /// <typeparam name="TDisplayOptions">Display options</typeparam>
+    /// <typeparam name="TResult">Result type</typeparam>
+    /// <param name="api">The api</param>
+    /// <param name="displayOptions">The display options</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>A list of all items</returns>
+    public static Task<CloudFlareResult<IReadOnlyList<TResult>>> GetAllAsync<TDisplayOptions, TResult>(
+        this IGetApi<TDisplayOptions, TResult> api,
+        TDisplayOptions displayOptions = null,
+        CancellationToken cancellationToken = default)
+        where TDisplayOptions : UnOrderableDisplayOptions, new()
+    {
+        return GetAllAsync(api.GetAsync, displayOptions, cancellationToken);
+    }
+
+    /// <summary>
+    /// Get all results from all the pages.
+    /// </summary>
+    /// <typeparam name="TFilter">Filtering options</typeparam>
+    /// <typeparam name="TDisplayOptions">Display options</typeparam>
+    /// <typeparam name="TResult">Result type</typeparam>
+    /// <param name="api">The api</param>
+    /// <param name="filter">The filter</param>
+    /// <param name="displayOptions">The display options</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>A list of all items</returns>
+    public static Task<CloudFlareResult<IReadOnlyList<TResult>>> GetAllAsync<TFilter, TDisplayOptions, TResult>(
+        this IGetApi<TFilter, TDisplayOptions, TResult> api,
+        TFilter filter = null,
+        TDisplayOptions displayOptions = null,
+        CancellationToken cancellationToken = default)
+        where TFilter : class
+        where TDisplayOptions : UnOrderableDisplayOptions, new()
+    {
+        return GetAllAsync((options, token) => api.GetAsync(filter, options, token), displayOptions, cancellationToken);
+    }
+
+    private static async Task<CloudFlareResult<IReadOnlyList<TResult>>> GetAllAsync<TDisplayOptions, TResult>(
+        Func<TDisplayOptions, CancellationToken, Task<CloudFlareResult<IReadOnlyList<TResult>>>> fetch,
+        TDisplayOptions displayOptions = null,
+        CancellationToken cancellationToken = default)
+        where TDisplayOptions : UnOrderableDisplayOptions, new()
+    {
+        displayOptions ??= new TDisplayOptions();
+
+        if (displayOptions.Page.HasValue && displayOptions.Page != 1)
+        {
+            throw new ArgumentException("Page should not be set", nameof(displayOptions));
+        }
+
+        var initialPage = displayOptions.Page;
+
+        try
+        {
+            displayOptions.Page = 1;
+
+            var firstPage = await fetch(displayOptions, cancellationToken).ConfigureAwait(false);
+
+            if (!firstPage.Success || firstPage.ResultInfo.TotalPage == 1)
+            {
+                return firstPage;
+            }
+
+            var timing = new TimingInfo
+            {
+                StartDateTime = firstPage.Timing.StartDateTime,
+                ProcessTime = firstPage.Timing.ProcessTime
+            };
+
+            var result = new List<TResult>(firstPage.ResultInfo.Count);
+            result.AddRange(firstPage.Result);
+
+            for (var i = 2; i <= firstPage.ResultInfo.TotalPage; i++)
+            {
+                displayOptions.Page = i;
+
+                var page = await fetch(displayOptions, cancellationToken).ConfigureAwait(false);
+
+                timing.ProcessTime += page.Timing.ProcessTime;
+                timing.EndDateTime = page.Timing.EndDateTime;
+
+                if (!page.Success)
+                {
+                    return new CloudFlareResult<IReadOnlyList<TResult>>(
+                        result,
+                        page.ResultInfo,
+                        false,
+                        page.Messages,
+                        page.Errors,
+                        timing);
+                }
+
+                result.AddRange(page.Result);
+            }
+
+            displayOptions.Page = initialPage;
+
+            return new CloudFlareResult<IReadOnlyList<TResult>>(
+                result,
+                firstPage.ResultInfo,
+                true,
+                firstPage.Messages,
+                firstPage.Errors,
+                timing);
+        }
+        finally
+        {
+            // Reset the parameter to its original value
+            displayOptions.Page = initialPage;
+        }
+    }
+}

--- a/CloudFlare.Client/Helpers/CertificateExpiresOnConverter.cs
+++ b/CloudFlare.Client/Helpers/CertificateExpiresOnConverter.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace CloudFlare.Client.Helpers
+{
+    /// <summary>
+    /// Formats the certificate expiration date.
+    /// </summary>
+    internal class CertificateExpiresOnConverter : DateTimeConverterBase
+    {
+        private const string Format = "yyyy-MM-dd HH:mm:ss zzzz 'UTC'";
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.Value is null || !DateTime.TryParseExact(reader.Value.ToString(), Format, null, System.Globalization.DateTimeStyles.None, out var date))
+            {
+                throw new JsonSerializationException("Invalid date format");
+            }
+
+            return date;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            switch (value)
+            {
+                case null:
+                    writer.WriteNull();
+                    break;
+                case DateTime date:
+                    writer.WriteValue(date.ToString(Format));
+                    break;
+                case DateTimeOffset offset:
+                    writer.WriteValue(offset.ToString(Format));
+                    break;
+                default:
+                    throw new JsonSerializationException("Expected date object value.");
+            }
+        }
+    }
+}

--- a/CloudFlare.Client/ICloudFlareClient.cs
+++ b/CloudFlare.Client/ICloudFlareClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using CloudFlare.Client.Client.Accounts;
+using CloudFlare.Client.Client.Certificates;
 using CloudFlare.Client.Client.Users;
 using CloudFlare.Client.Client.Zones;
 
@@ -27,5 +28,11 @@ namespace CloudFlare.Client
         /// </summary>
         /// <value>The implementation of the zones interaction</value>
         IZones Zones { get; }
+
+        /// <summary>
+        /// Certificates
+        /// </summary>
+        /// <value>The implementation of the certificates interaction</value>
+        ICertificates Certificates { get; }
     }
 }


### PR DESCRIPTION
Depends on #89. See https://github.com/zingz0r/CloudFlare.Client/commit/00b4f0d4c83cf4ea190ecb64c0a243f93abe2d0e for only the changes of this PR.

`client.Zones.GetAsync` currently only gets the first page. If you want to get all the pages, you'll have to make your own implementation. This PR adds an extension method to fetch all pages of the results.

It has been implemented in:
1. IZones
2. IMembers
3. ICertificates (added in #89)
4. IAccounts

Example:

```cs
CloudFlareResult<IReadOnlyList<Zone>> zones = await client.Zones.GetAllAsync(zoneFilter);

// zones.Result contains the results of all the pages
```