### PR TITLE
Add Cache Purge By Url

### DIFF
--- a/CloudFlare.Client.Test/TestData/CachePurgeFileTestData.cs
+++ b/CloudFlare.Client.Test/TestData/CachePurgeFileTestData.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using CloudFlare.Client.Client.Zones;
+
+namespace CloudFlare.Client.Test.TestData
+{
+    public static class CachePurgeFileTestData
+    {
+        public static List<CachePurgeFile> CachePurgeFiles { get; set; } = new()
+        {
+            new CachePurgeFile { Url = "https://example.com/" },
+            new CachePurgeFile { Url = "https://example.com/my-page?q=apple" },
+            new CachePurgeFile
+            {
+                Url = "https://example.com/my-page?q=apple",
+                Headers = new Dictionary<string, string> { { "Origin", "https://example2.com" } }
+            }
+        };
+    }
+}

--- a/CloudFlare.Client.Test/TestData/CachePurgeFileTestData.cs
+++ b/CloudFlare.Client.Test/TestData/CachePurgeFileTestData.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using CloudFlare.Client.Client.Zones;
+using CloudFlare.Client.Api.Zones;
 
 namespace CloudFlare.Client.Test.TestData
 {

--- a/CloudFlare.Client.Test/TestData/ZoneTestData.cs
+++ b/CloudFlare.Client.Test/TestData/ZoneTestData.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using CloudFlare.Client.Api.Zones;
+using CloudFlare.Client.Client.Zones;
 using CloudFlare.Client.Enumerators;
 
 namespace CloudFlare.Client.Test.TestData
@@ -79,6 +80,26 @@ namespace CloudFlare.Client.Test.TestData
                     LegacyId = LegacyType.Free,
                     Currency = "USD",
                     Price = 0,
+                }
+            }
+        };
+
+        public static List<CachePurgeFile> CachePurgeFiles { get; set; } = new()
+        {
+            new CachePurgeFile
+            {
+                Url = "https://example.com/"
+            },
+            new CachePurgeFile
+            {
+                Url = "https://example.com/my-page?q=apple"
+            },   
+            new CachePurgeFile
+            {
+                Url = "https://example.com/my-page?q=apple",
+                Headers = new Dictionary<string, string>
+                {
+                    { "Origin", "https://example2.com" }
                 }
             }
         };

--- a/CloudFlare.Client.Test/TestData/ZoneTestData.cs
+++ b/CloudFlare.Client.Test/TestData/ZoneTestData.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using CloudFlare.Client.Api.Zones;
-using CloudFlare.Client.Client.Zones;
 using CloudFlare.Client.Enumerators;
 
 namespace CloudFlare.Client.Test.TestData
@@ -80,26 +79,6 @@ namespace CloudFlare.Client.Test.TestData
                     LegacyId = LegacyType.Free,
                     Currency = "USD",
                     Price = 0,
-                }
-            }
-        };
-
-        public static List<CachePurgeFile> CachePurgeFiles { get; set; } = new()
-        {
-            new CachePurgeFile
-            {
-                Url = "https://example.com/"
-            },
-            new CachePurgeFile
-            {
-                Url = "https://example.com/my-page?q=apple"
-            },   
-            new CachePurgeFile
-            {
-                Url = "https://example.com/my-page?q=apple",
-                Headers = new Dictionary<string, string>
-                {
-                    { "Origin", "https://example2.com" }
                 }
             }
         };

--- a/CloudFlare.Client.Test/Zones/ZonesUnitTests.cs
+++ b/CloudFlare.Client.Test/Zones/ZonesUnitTests.cs
@@ -181,6 +181,25 @@ namespace CloudFlare.Client.Test.Zones
         }
         
         [Fact]
+        public async Task TestPurgeFilesWithStringListAsync()
+        {
+            var zone = ZoneTestData.Zones.First();
+            var files = CachePurgeFileTestData.CachePurgeFiles;
+            var expected = new Zone { Id = zone.Id };
+
+            _wireMockServer
+                .Given(Request.Create().WithPath($"/{ZoneEndpoints.Base}/{zone.Id}/{ZoneEndpoints.PurgeCache}").UsingPost())
+                .RespondWith(Response.Create().WithStatusCode(200)
+                    .WithBody(WireMockResponseHelper.CreateTestResponse(expected)));
+
+            using var client = new CloudFlareClient(WireMockConnection.ApiKeyAuthentication, _connectionInfo);
+
+            var purge = await client.Zones.PurgeFilesAsync(zone.Id, files.Select(x => x.Url));
+
+            purge.Result.Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
         public async Task TestPurgeFilesAsync()
         {
             var zone = ZoneTestData.Zones.First();

--- a/CloudFlare.Client.Test/Zones/ZonesUnitTests.cs
+++ b/CloudFlare.Client.Test/Zones/ZonesUnitTests.cs
@@ -184,7 +184,7 @@ namespace CloudFlare.Client.Test.Zones
         public async Task TestPurgeFilesAsync()
         {
             var zone = ZoneTestData.Zones.First();
-            var files = ZoneTestData.CachePurgeFiles;
+            var files = CachePurgeFileTestData.CachePurgeFiles;
             var expected = new Zone { Id = zone.Id };
 
             _wireMockServer

--- a/CloudFlare.Client.Test/Zones/ZonesUnitTests.cs
+++ b/CloudFlare.Client.Test/Zones/ZonesUnitTests.cs
@@ -163,7 +163,6 @@ namespace CloudFlare.Client.Test.Zones
         }
 
         [Fact]
-
         public async Task TestPurgeAllFilesAsync()
         {
             var zone = ZoneTestData.Zones.First();
@@ -177,6 +176,25 @@ namespace CloudFlare.Client.Test.Zones
             using var client = new CloudFlareClient(WireMockConnection.ApiKeyAuthentication, _connectionInfo);
 
             var purge = await client.Zones.PurgeAllFilesAsync(zone.Id, true);
+
+            purge.Result.Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
+        public async Task TestPurgeFilesAsync()
+        {
+            var zone = ZoneTestData.Zones.First();
+            var files = ZoneTestData.CachePurgeFiles;
+            var expected = new Zone { Id = zone.Id };
+
+            _wireMockServer
+                .Given(Request.Create().WithPath($"/{ZoneEndpoints.Base}/{zone.Id}/{ZoneEndpoints.PurgeCache}").UsingPost())
+                .RespondWith(Response.Create().WithStatusCode(200)
+                    .WithBody(WireMockResponseHelper.CreateTestResponse(expected)));
+
+            using var client = new CloudFlareClient(WireMockConnection.ApiKeyAuthentication, _connectionInfo);
+
+            var purge = await client.Zones.PurgeFilesAsync(zone.Id, files);
 
             purge.Result.Should().BeEquivalentTo(expected);
         }

--- a/CloudFlare.Client/Api/Parameters/Outgoing.cs
+++ b/CloudFlare.Client/Api/Parameters/Outgoing.cs
@@ -3,5 +3,6 @@
     internal static class Outgoing
     {
         public const string PurgeEverything = "purge_everything";
+        public const string Files = "files";
     }
 }

--- a/CloudFlare.Client/Api/Zones/CachePurgeFile.cs
+++ b/CloudFlare.Client/Api/Zones/CachePurgeFile.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
-namespace CloudFlare.Client.Client.Zones;
+namespace CloudFlare.Client.Api.Zones;
 
 /// <summary>
-/// CachePurgeFile
+/// Represents a file to be purged from CloudFlare's cache.
 /// </summary>
 public class CachePurgeFile
 {

--- a/CloudFlare.Client/Client/Zones/CachePurgeFile.cs
+++ b/CloudFlare.Client/Client/Zones/CachePurgeFile.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace CloudFlare.Client.Client.Zones;
+
+/// <summary>
+/// CachePurgeFile
+/// </summary>
+public class CachePurgeFile
+{
+    /// <summary>
+    /// The url that should be purged. Wildcards are not supported. Non-ignored query strings must be included.
+    /// </summary>
+    [JsonProperty("url")]
+    public string Url { get; set; }
+
+    /// <summary>
+    /// To purge files with custom cache keys, include the headers used to compute the cache key.
+    /// If you have a device type or geo in your cache key, you will need to include the CF-Device-Type or
+    /// CF-IPCountry headers.
+    /// If you have lang in your cache key, you will need to include the Accept-Language header.
+    /// </summary>
+    [JsonProperty("headers")]
+    public Dictionary<string, string> Headers { get; set; }
+}

--- a/CloudFlare.Client/Client/Zones/IZones.cs
+++ b/CloudFlare.Client/Client/Zones/IZones.cs
@@ -105,6 +105,15 @@ namespace CloudFlare.Client.Client.Zones
         /// <param name="files">The files that should be purged</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The purged zone cache result</returns>
+        Task<CloudFlareResult<Zone>> PurgeFilesAsync(string zoneId, IReadOnlyList<string> files, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Purge specified files from CloudFlare's cache
+        /// </summary>
+        /// <param name="zoneId">Zone identifier</param>
+        /// <param name="files">The files that should be purged</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>The purged zone cache result</returns>
         Task<CloudFlareResult<Zone>> PurgeFilesAsync(string zoneId, IReadOnlyList<CachePurgeFile> files, CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/CloudFlare.Client/Client/Zones/IZones.cs
+++ b/CloudFlare.Client/Client/Zones/IZones.cs
@@ -99,6 +99,15 @@ namespace CloudFlare.Client.Client.Zones
         Task<CloudFlareResult<Zone>> PurgeAllFilesAsync(string zoneId, bool purgeEverything, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Purge specified files from CloudFlare's cache
+        /// </summary>
+        /// <param name="zoneId">Zone identifier</param>
+        /// <param name="files">The files that should be purged</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>The purged zone cache result</returns>
+        Task<CloudFlareResult<Zone>> PurgeFilesAsync(string zoneId, IReadOnlyList<CachePurgeFile> files, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Change key zone property with new value
         /// </summary>
         /// <param name="zoneId">Zone identifier</param>

--- a/CloudFlare.Client/Client/Zones/IZones.cs
+++ b/CloudFlare.Client/Client/Zones/IZones.cs
@@ -105,7 +105,7 @@ namespace CloudFlare.Client.Client.Zones
         /// <param name="files">The files that should be purged</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The purged zone cache result</returns>
-        Task<CloudFlareResult<Zone>> PurgeFilesAsync(string zoneId, IReadOnlyList<string> files, CancellationToken cancellationToken = default);
+        Task<CloudFlareResult<Zone>> PurgeFilesAsync(string zoneId, IEnumerable<string> files, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Purge specified files from CloudFlare's cache
@@ -114,7 +114,7 @@ namespace CloudFlare.Client.Client.Zones
         /// <param name="files">The files that should be purged</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The purged zone cache result</returns>
-        Task<CloudFlareResult<Zone>> PurgeFilesAsync(string zoneId, IReadOnlyList<CachePurgeFile> files, CancellationToken cancellationToken = default);
+        Task<CloudFlareResult<Zone>> PurgeFilesAsync(string zoneId, IEnumerable<CachePurgeFile> files, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Change key zone property with new value

--- a/CloudFlare.Client/Client/Zones/Zones.cs
+++ b/CloudFlare.Client/Client/Zones/Zones.cs
@@ -107,6 +107,15 @@ namespace CloudFlare.Client.Client.Zones
         }
 
         /// <inheritdoc />
+        public async Task<CloudFlareResult<Zone>> PurgeFilesAsync(string zoneId, IReadOnlyList<CachePurgeFile> files, CancellationToken cancellationToken = default)
+        {
+            var content = new Dictionary<string, IReadOnlyList<CachePurgeFile>> { { Outgoing.Files, files } };
+
+            var requestUri = $"{ZoneEndpoints.Base}/{zoneId}/{ZoneEndpoints.PurgeCache}";
+            return await Connection.PostAsync<Zone, Dictionary<string, IReadOnlyList<CachePurgeFile>>>(requestUri, content, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
         public async Task<CloudFlareResult<Zone>> UpdateAsync(string zoneId, ModifiedZone modifiedZone, CancellationToken cancellationToken = default)
         {
             var requestUri = $"{ZoneEndpoints.Base}/{zoneId}";

--- a/CloudFlare.Client/Client/Zones/Zones.cs
+++ b/CloudFlare.Client/Client/Zones/Zones.cs
@@ -108,6 +108,17 @@ namespace CloudFlare.Client.Client.Zones
         }
 
         /// <inheritdoc />
+        public Task<CloudFlareResult<Zone>> PurgeFilesAsync(string zoneId, IReadOnlyList<string> files, CancellationToken cancellationToken = default)
+        {
+            return PurgeFilesAsync(
+                zoneId,
+                files
+                    .Select(url => new CachePurgeFile { Url = url, Headers = new Dictionary<string, string>() })
+                    .ToList(),
+                cancellationToken);
+        }
+
+        /// <inheritdoc />
         public async Task<CloudFlareResult<Zone>> PurgeFilesAsync(string zoneId, IReadOnlyList<CachePurgeFile> files, CancellationToken cancellationToken = default)
         {
             var content = new Dictionary<string, IReadOnlyList<CachePurgeFile>>

--- a/CloudFlare.Client/Client/Zones/Zones.cs
+++ b/CloudFlare.Client/Client/Zones/Zones.cs
@@ -108,7 +108,7 @@ namespace CloudFlare.Client.Client.Zones
         }
 
         /// <inheritdoc />
-        public Task<CloudFlareResult<Zone>> PurgeFilesAsync(string zoneId, IReadOnlyList<string> files, CancellationToken cancellationToken = default)
+        public Task<CloudFlareResult<Zone>> PurgeFilesAsync(string zoneId, IEnumerable<string> files, CancellationToken cancellationToken = default)
         {
             return PurgeFilesAsync(
                 zoneId,
@@ -119,7 +119,7 @@ namespace CloudFlare.Client.Client.Zones
         }
 
         /// <inheritdoc />
-        public async Task<CloudFlareResult<Zone>> PurgeFilesAsync(string zoneId, IReadOnlyList<CachePurgeFile> files, CancellationToken cancellationToken = default)
+        public async Task<CloudFlareResult<Zone>> PurgeFilesAsync(string zoneId, IEnumerable<CachePurgeFile> files, CancellationToken cancellationToken = default)
         {
             var content = new Dictionary<string, IReadOnlyList<CachePurgeFile>>
             {

--- a/CloudFlare.Client/Client/Zones/Zones.cs
+++ b/CloudFlare.Client/Client/Zones/Zones.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using CloudFlare.Client.Api.Display;
@@ -109,8 +110,23 @@ namespace CloudFlare.Client.Client.Zones
         /// <inheritdoc />
         public async Task<CloudFlareResult<Zone>> PurgeFilesAsync(string zoneId, IReadOnlyList<CachePurgeFile> files, CancellationToken cancellationToken = default)
         {
-            var content = new Dictionary<string, IReadOnlyList<CachePurgeFile>> { { Outgoing.Files, files } };
-
+            var content = new Dictionary<string, IReadOnlyList<CachePurgeFile>>
+            {
+                {
+                    Outgoing.Files,
+                    files
+                        .Select(file => new CachePurgeFile
+                        {
+                            Url = file.Url,
+                            Headers = file.Headers == null ?
+                                new Dictionary<string, string>() :
+                                file.Headers
+                                    .Where(header => header.Value != null)
+                                    .ToDictionary(header => header.Key, header => header.Value)
+                        })
+                        .ToList()
+                }
+            };
             var requestUri = $"{ZoneEndpoints.Base}/{zoneId}/{ZoneEndpoints.PurgeCache}";
             return await Connection.PostAsync<Zone, Dictionary<string, IReadOnlyList<CachePurgeFile>>>(requestUri, content, cancellationToken).ConfigureAwait(false);
         }

--- a/CloudFlare.Client/Client/Zones/Zones.cs
+++ b/CloudFlare.Client/Client/Zones/Zones.cs
@@ -110,34 +110,28 @@ namespace CloudFlare.Client.Client.Zones
         /// <inheritdoc />
         public Task<CloudFlareResult<Zone>> PurgeFilesAsync(string zoneId, IEnumerable<string> files, CancellationToken cancellationToken = default)
         {
-            return PurgeFilesAsync(
-                zoneId,
-                files
-                    .Select(url => new CachePurgeFile { Url = url, Headers = new Dictionary<string, string>() })
-                    .ToList(),
-                cancellationToken);
+            var cachedPurgeFiles = files.Select(url => new CachePurgeFile
+            {
+                Url = url,
+                Headers = new Dictionary<string, string>()
+            });
+
+            return PurgeFilesAsync(zoneId, cachedPurgeFiles, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<CloudFlareResult<Zone>> PurgeFilesAsync(string zoneId, IEnumerable<CachePurgeFile> files, CancellationToken cancellationToken = default)
         {
-            var content = new Dictionary<string, IReadOnlyList<CachePurgeFile>>
+            var headers = files.Select(file => new CachePurgeFile
             {
-                {
-                    Outgoing.Files,
-                    files
-                        .Select(file => new CachePurgeFile
-                        {
-                            Url = file.Url,
-                            Headers = file.Headers == null ?
-                                new Dictionary<string, string>() :
-                                file.Headers
-                                    .Where(header => header.Value != null)
-                                    .ToDictionary(header => header.Key, header => header.Value)
-                        })
-                        .ToList()
-                }
-            };
+                Url = file.Url,
+                Headers = file.Headers == null
+                    ? new Dictionary<string, string>()
+                    : file.Headers.Where(header => header.Value != null).ToDictionary(header => header.Key, header => header.Value)
+            }).ToList();
+
+            var content = new Dictionary<string, IReadOnlyList<CachePurgeFile>> { { Outgoing.Files, headers } };
+
             var requestUri = $"{ZoneEndpoints.Base}/{zoneId}/{ZoneEndpoints.PurgeCache}";
             return await Connection.PostAsync<Zone, Dictionary<string, IReadOnlyList<CachePurgeFile>>>(requestUri, content, cancellationToken).ConfigureAwait(false);
         }


### PR DESCRIPTION
Implements url-based cache purging as described in #94.

### Current state
Fully tested against a live CloudFlare deployment.
Tried all request variants I could think of, to find all variants that could cause errors.
Ready for review and merging (if there are no review comments).