### PR TITLE
Fix missing paging options for Role.GetAsync

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ indent_style = space
 # Code files
 [*.{cs,csx,vb,vbx}]
 indent_size = 4
-insert_final_newline = false
+insert_final_newline = true
 charset = utf-8-bom
 
 ###############################

--- a/CloudFlare.Client.Test/Accounts/RolesUnitTests.cs
+++ b/CloudFlare.Client.Test/Accounts/RolesUnitTests.cs
@@ -1,7 +1,10 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
+using CloudFlare.Client.Api.Display;
+using CloudFlare.Client.Api.Parameters;
 using CloudFlare.Client.Api.Parameters.Endpoints;
 using CloudFlare.Client.Contexts;
+using CloudFlare.Client.Enumerators;
 using CloudFlare.Client.Test.Helpers;
 using CloudFlare.Client.Test.TestData;
 using FluentAssertions;
@@ -27,15 +30,19 @@ namespace CloudFlare.Client.Test.Accounts
         public async Task TestGetRolesAsync()
         {
             var accountId = AccountTestData.Accounts.First().Id;
+            var displayOptions = new DisplayOptions { Page = 1, PerPage = 30 };
 
             _wireMockServer
-                .Given(Request.Create().WithPath($"/{AccountEndpoints.Base}/{accountId}/{AccountEndpoints.Roles}").UsingGet())
+                .Given(Request.Create().WithPath($"/{AccountEndpoints.Base}/{accountId}/{AccountEndpoints.Roles}")
+                    .WithParam(Filtering.Page)
+                    .WithParam(Filtering.PerPage)
+                    .UsingGet())
                 .RespondWith(Response.Create().WithStatusCode(200)
                     .WithBody(WireMockResponseHelper.CreateTestResponse(RoleTestData.Roles)));
 
             using var client = new CloudFlareClient(WireMockConnection.ApiKeyAuthentication, _connectionInfo);
 
-            var roles = await client.Accounts.Roles.GetAsync(accountId);
+            var roles = await client.Accounts.Roles.GetAsync(accountId, default, displayOptions);
 
             roles.Result.Should().BeEquivalentTo(RoleTestData.Roles);
         }

--- a/CloudFlare.Client/Client/Accounts/IRoles.cs
+++ b/CloudFlare.Client/Client/Accounts/IRoles.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using CloudFlare.Client.Api.Accounts.Roles;
+using CloudFlare.Client.Api.Display;
 using CloudFlare.Client.Api.Result;
 
 namespace CloudFlare.Client.Client.Accounts
@@ -16,8 +17,9 @@ namespace CloudFlare.Client.Client.Accounts
         /// </summary>
         /// <param name="accountId">Account identifier tag</param>
         /// <param name="cancellationToken">Cancellation token</param>
+        /// <param name="displayOptions">Display Options</param>
         /// <returns>The requested role</returns>
-        Task<CloudFlareResult<IReadOnlyList<Role>>> GetAsync(string accountId, CancellationToken cancellationToken = default);
+        Task<CloudFlareResult<IReadOnlyList<Role>>> GetAsync(string accountId, CancellationToken cancellationToken = default, DisplayOptions displayOptions = null);
 
         /// <summary>
         /// Get information about a specific role for an account
@@ -25,7 +27,8 @@ namespace CloudFlare.Client.Client.Accounts
         /// <param name="accountId">Account identifier tag</param>
         /// <param name="roleId">Role identifier tag</param>
         /// <param name="cancellationToken">Cancellation token</param>
+        /// <param name="displayOptions">Display Options</param>
         /// <returns>The requested role details</returns>
-        Task<CloudFlareResult<Role>> GetDetailsAsync(string accountId, string roleId, CancellationToken cancellationToken = default);
+        Task<CloudFlareResult<Role>> GetDetailsAsync(string accountId, string roleId, CancellationToken cancellationToken = default, DisplayOptions displayOptions = null);
     }
 }

--- a/CloudFlare.Client/Client/Accounts/IRoles.cs
+++ b/CloudFlare.Client/Client/Accounts/IRoles.cs
@@ -27,8 +27,7 @@ namespace CloudFlare.Client.Client.Accounts
         /// <param name="accountId">Account identifier tag</param>
         /// <param name="roleId">Role identifier tag</param>
         /// <param name="cancellationToken">Cancellation token</param>
-        /// <param name="displayOptions">Display Options</param>
         /// <returns>The requested role details</returns>
-        Task<CloudFlareResult<Role>> GetDetailsAsync(string accountId, string roleId, CancellationToken cancellationToken = default, DisplayOptions displayOptions = null);
+        Task<CloudFlareResult<Role>> GetDetailsAsync(string accountId, string roleId, CancellationToken cancellationToken = default);
     }
 }

--- a/CloudFlare.Client/Client/Accounts/Roles.cs
+++ b/CloudFlare.Client/Client/Accounts/Roles.cs
@@ -2,9 +2,12 @@
 using System.Threading;
 using System.Threading.Tasks;
 using CloudFlare.Client.Api.Accounts.Roles;
+using CloudFlare.Client.Api.Display;
+using CloudFlare.Client.Api.Parameters;
 using CloudFlare.Client.Api.Parameters.Endpoints;
 using CloudFlare.Client.Api.Result;
 using CloudFlare.Client.Contexts;
+using CloudFlare.Client.Helpers;
 
 namespace CloudFlare.Client.Client.Accounts
 {
@@ -21,16 +24,34 @@ namespace CloudFlare.Client.Client.Accounts
         }
 
         /// <inheritdoc />
-        public async Task<CloudFlareResult<IReadOnlyList<Role>>> GetAsync(string accountId, CancellationToken cancellationToken = default)
+        public async Task<CloudFlareResult<IReadOnlyList<Role>>> GetAsync(string accountId, CancellationToken cancellationToken = default, DisplayOptions displayOptions = null)
         {
-            var requestUri = $"{AccountEndpoints.Base}/{accountId}/{AccountEndpoints.Roles}";
+            var requestUri =
+                $"{AccountEndpoints.Base}/{accountId}/{AccountEndpoints.Roles}";
+            var builder = new ParameterBuilderHelper()
+                .InsertValue(Filtering.Page, displayOptions?.Page)
+                .InsertValue(Filtering.PerPage, displayOptions?.PerPage);
+            if (builder.ParameterCollection.HasKeys())
+            {
+                requestUri = $"{requestUri}?{builder.ParameterCollection}";
+            }
+
             return await Connection.GetAsync<IReadOnlyList<Role>>(requestUri, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<CloudFlareResult<Role>> GetDetailsAsync(string accountId, string roleId, CancellationToken cancellationToken = default)
+        public async Task<CloudFlareResult<Role>> GetDetailsAsync(string accountId, string roleId, CancellationToken cancellationToken = default, DisplayOptions displayOptions = null)
         {
             var requestUri = $"{AccountEndpoints.Base}/{accountId}/{AccountEndpoints.Roles}/{roleId}";
+            var builder = new ParameterBuilderHelper()
+                .InsertValue(Filtering.Page, displayOptions?.Page)
+                .InsertValue(Filtering.PerPage, displayOptions?.PerPage)
+                .InsertValue(Filtering.Direction, displayOptions?.Order);
+            if (builder.ParameterCollection.HasKeys())
+            {
+                requestUri = $"{requestUri}/?{builder.ParameterCollection}";
+            }
+
             return await Connection.GetAsync<Role>(requestUri, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/CloudFlare.Client/Client/Accounts/Roles.cs
+++ b/CloudFlare.Client/Client/Accounts/Roles.cs
@@ -40,18 +40,9 @@ namespace CloudFlare.Client.Client.Accounts
         }
 
         /// <inheritdoc />
-        public async Task<CloudFlareResult<Role>> GetDetailsAsync(string accountId, string roleId, CancellationToken cancellationToken = default, DisplayOptions displayOptions = null)
+        public async Task<CloudFlareResult<Role>> GetDetailsAsync(string accountId, string roleId, CancellationToken cancellationToken = default)
         {
             var requestUri = $"{AccountEndpoints.Base}/{accountId}/{AccountEndpoints.Roles}/{roleId}";
-            var builder = new ParameterBuilderHelper()
-                .InsertValue(Filtering.Page, displayOptions?.Page)
-                .InsertValue(Filtering.PerPage, displayOptions?.PerPage)
-                .InsertValue(Filtering.Direction, displayOptions?.Order);
-            if (builder.ParameterCollection.HasKeys())
-            {
-                requestUri = $"{requestUri}/?{builder.ParameterCollection}";
-            }
-
             return await Connection.GetAsync<Role>(requestUri, cancellationToken).ConfigureAwait(false);
         }
     }


### PR DESCRIPTION
The default paging options for the Cloudflare API limit results to 20 items.  This default does not work when returning Role's on a Cloudflare Enterprise account as there are 52 total Roles.  

To fix I added the existing DisplayOptions logic to inject paging control into the Role.GetAsync method.  
The options are at the very end and optional so existing clients wont have a breaking change however it should be moved so that the Cancellation token is at the end at some point as that is recommended however it would be a breaking change.

Fixed the tests for Role to now include those parameters to match other tests that use the DisplayOptions logic

Also fixed an issue with the .editorconfig file that was making Rider and stylecop fight over the ending whitespace