### PR TITLE
Fix FluentAssertions version to 7.0.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -16,7 +16,7 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="DeepCloner" Version="0.10.4" />
-    <PackageVersion Include="FluentAssertions" Version="8.0.1" />
+    <PackageVersion Include="FluentAssertions" Version="[7.0.0]" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.3.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />


### PR DESCRIPTION
Downgrade and fix the FluentAssertions version to 7.0.0 to avoid commercial use restrictions on this library. Higher versions of FluentAssertions do not provide any benefits to this library. Newer versions of FluentAssertions cannot be used for free in commercial products. Therefore, using versions higher than 7.0.0 in this library restricts its use to non-commercial purposes (or requires purchasing a license for FluentAssertions).